### PR TITLE
Fix BlockArg scope collision in nested loops

### DIFF
--- a/src/ir.jl
+++ b/src/ir.jl
@@ -498,29 +498,101 @@ function apply_substitutions!(op::IfOp, subs::Substitutions)
     apply_substitutions!(op.else_region, subs)
 end
 
-function apply_substitutions!(op::LoopOp, subs::Substitutions)
-    for (j, v) in enumerate(op.init_values)
-        op.init_values[j] = substitute_ssa(v, subs)
-    end
-    apply_substitutions!(op.body, subs)
-end
-
-function apply_substitutions!(op::WhileOp, subs::Substitutions)
-    for (j, v) in enumerate(op.init_values)
-        op.init_values[j] = substitute_ssa(v, subs)
-    end
-    apply_substitutions!(op.before, subs)
-    apply_substitutions!(op.after, subs)
-end
-
 function apply_substitutions!(op::ForOp, subs::Substitutions)
+    # Substitute bounds and init_values (evaluated in outer scope)
     op.lower = substitute_ssa(op.lower, subs)
     op.upper = substitute_ssa(op.upper, subs)
     op.step = substitute_ssa(op.step, subs)
     for (j, v) in enumerate(op.init_values)
         op.init_values[j] = substitute_ssa(v, subs)
     end
-    apply_substitutions!(op.body, subs)
+
+    # Thread outer BlockArgs through inner loop as invariant carries.
+    # Without this, an outer BlockArg(1) collides with the inner loop's own BlockArg(1) (its IV).
+    isempty(subs) && return
+    inner_subs = Substitutions()
+    for (ssa_idx, outer_arg) in subs
+        next_id = isempty(op.body.args) ? 2 : maximum(a.id for a in op.body.args) + 1
+        inner_arg = BlockArg(next_id, outer_arg.type)
+        push!(op.body.args, inner_arg)
+        push!(op.init_values, outer_arg)
+        if op.body.terminator isa ContinueOp
+            push!(op.body.terminator.values, inner_arg)
+        end
+        inner_subs[ssa_idx] = inner_arg
+    end
+    apply_substitutions!(op.body, inner_subs)
+end
+
+function apply_substitutions!(op::LoopOp, subs::Substitutions)
+    for (j, v) in enumerate(op.init_values)
+        op.init_values[j] = substitute_ssa(v, subs)
+    end
+
+    isempty(subs) && return
+    inner_subs = Substitutions()
+    for (ssa_idx, outer_arg) in subs
+        next_id = isempty(op.body.args) ? 1 : maximum(a.id for a in op.body.args) + 1
+        inner_arg = BlockArg(next_id, outer_arg.type)
+        push!(op.body.args, inner_arg)
+        push!(op.init_values, outer_arg)
+        _thread_loop_carry!(op.body, inner_arg)
+        inner_subs[ssa_idx] = inner_arg
+    end
+    apply_substitutions!(op.body, inner_subs)
+end
+
+"""
+    _thread_loop_carry!(block, inner_arg)
+
+Push `inner_arg` to every ContinueOp and BreakOp terminator reachable from `block`,
+recursing into nested IfOps (but not into nested loop ops, which have their own scopes).
+"""
+function _thread_loop_carry!(block::Block, inner_arg::BlockArg)
+    if block.terminator isa ContinueOp
+        push!(block.terminator.values, inner_arg)
+    elseif block.terminator isa BreakOp
+        push!(block.terminator.values, inner_arg)
+    end
+    for stmt in statements(block.body)
+        if stmt isa IfOp
+            _thread_loop_carry!(stmt.then_region, inner_arg)
+            _thread_loop_carry!(stmt.else_region, inner_arg)
+        end
+    end
+end
+
+function apply_substitutions!(op::WhileOp, subs::Substitutions)
+    for (j, v) in enumerate(op.init_values)
+        op.init_values[j] = substitute_ssa(v, subs)
+    end
+
+    isempty(subs) && return
+    before_subs = Substitutions()
+    after_subs = Substitutions()
+    for (ssa_idx, outer_arg) in subs
+        # before region
+        next_before_id = isempty(op.before.args) ? 1 : maximum(a.id for a in op.before.args) + 1
+        before_arg = BlockArg(next_before_id, outer_arg.type)
+        push!(op.before.args, before_arg)
+        push!(op.init_values, outer_arg)
+        if op.before.terminator isa ConditionOp
+            push!(op.before.terminator.args, before_arg)
+        end
+
+        # after region
+        next_after_id = isempty(op.after.args) ? 1 : maximum(a.id for a in op.after.args) + 1
+        after_arg = BlockArg(next_after_id, outer_arg.type)
+        push!(op.after.args, after_arg)
+        if op.after.terminator isa YieldOp
+            push!(op.after.terminator.values, after_arg)
+        end
+
+        before_subs[ssa_idx] = before_arg
+        after_subs[ssa_idx] = after_arg
+    end
+    apply_substitutions!(op.before, before_subs)
+    apply_substitutions!(op.after, after_subs)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -716,6 +716,49 @@ end
     end
 end
 
+@testset "outer IV used inside inner loop" begin
+    sci, _ = code_structured(Tuple{Int, Int}) do n::Int, m::Int
+        acc = 0
+        i = 0
+        while i < n
+            j = 0
+            while j < m
+                acc += i  # outer IV used in inner body
+                j += 1
+            end
+            i += 1
+        end
+        return acc
+    end |> only
+    validate_scf(sci)
+
+    # Verify the inner ForOp threads outer IV through as an extra init_value
+    outer_for = nothing
+    for (_, entry) in sci.entry.body
+        if entry.stmt isa ForOp
+            outer_for = entry.stmt
+            break
+        end
+    end
+    @test outer_for !== nothing
+
+    inner_for = nothing
+    for (_, entry) in outer_for.body.body
+        if entry.stmt isa ForOp
+            inner_for = entry.stmt
+            break
+        end
+    end
+    @test inner_for !== nothing
+
+    # Inner ForOp should have extra init_values for threaded outer BlockArgs.
+    # Original inner loop has 1 non-IV init_value (acc).
+    # The outer loop's subs has 2 entries (IV i + carried acc), both threaded through.
+    # After fix: 1 (acc) + 2 (outer IV + outer acc) = 3 init_values
+    @test length(inner_for.init_values) == 3
+    @test length(inner_for.body.args) == 3
+end
+
 end  # regression
 
 #=============================================================================


### PR DESCRIPTION
Found this while debugging a constant-memory fused SwiGLU kernel that needed to iterate over two dimensions. I ended up concluding that it was too slow (~4x) and that I should simply materialize two of the intermediates, but this fix was needed to even do it so I'd figure I should open a PR. Opus helped with diagnosing and solving.

## Summary

- Thread outer-scope `BlockArgs` through inner loops as loop-invariant carries in `apply_substitutions!`, preventing ID collisions between outer and inner loop block arguments
- Add regression test for outer IV used inside inner loop body

 ## Problem

When nested while loops reference the outer loop's induction variable inside the inner loop body (e.g., `load(w, (k, d))` where k is the outer IV), apply_substitutions! replaced outer IV references with `BlockArg(1)`, which collided with the inner loop's own `BlockArg(1)` (its IV). The codegen then mapped `BlockArg(1)` to the inner loop's IV instead of the outer loop's.

## Fix

For `ForOp`, `LoopOp`, and `WhileOp`: instead of passing outer subs directly into inner regions, create fresh BlockArgs with unique IDs, add them as loop-invariant carried values (`init_values` → `ContinueOp`/`YieldOp`), and apply the remapped substitutions to the body. Handles arbitrary nesting depth since each level remaps independently.