### PR TITLE
Support single-argument `code_structured(f)` by inferring argtypes

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,8 +2,17 @@
 
 export code_structured
 
+function default_tt(@nospecialize(f))
+    ms = methods(f)
+    if length(ms) == 1
+        return Base.tuple_type_tail(only(ms).sig)
+    else
+        return Tuple
+    end
+end
+
 """
-    code_structured(f, argtypes; validate=true, kwargs...) -> Vector{Pair{StructuredIRCode, DataType}}
+    code_structured(f, [argtypes]; validate=true, kwargs...) -> Vector{Pair{StructuredIRCode, DataType}}
 
 Returns an array of structured IR for the methods matching the given generic function
 and type signature.
@@ -13,7 +22,8 @@ restructured into nested SCF-style operations (if/for/while).
 
 # Arguments
 - `f`: The function to analyze
-- `argtypes`: Argument types as a tuple of types (e.g., `(Int, Float64)`)
+- `argtypes`: Argument types as a tuple of types (e.g., `Tuple{Int, Float64}`).
+  If omitted and `f` has exactly one method, the types are inferred from its signature.
 - `validate`: Whether to validate that all control flow was properly structured (default: true).
   When `true`, throws `UnstructuredControlFlowError` if any unstructured control flow remains.
 
@@ -42,7 +52,7 @@ julia> code_structured(f, Tuple{Int})
 julia> sci, ret_type = code_structured(f, Tuple{Int}) |> only  # destructure
 ```
 """
-function code_structured(@nospecialize(f), @nospecialize(argtypes);
+function code_structured(@nospecialize(f), @nospecialize(argtypes=default_tt(f));
                          validate::Bool=true, kwargs...)
     map(code_ircode(f, argtypes; kwargs...)) do (ir, ret_type)
         sci = StructuredIRCode(ir; validate)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,24 @@ end
     @test loop_ops[1] isa ForOp
 end
 
+@testset "code_structured single-argument form" begin
+    # Single-method function: argtypes inferred from signature
+    h_single(x::Int) = x > 0 ? x + 1 : x - 1
+    sci1, ret1 = code_structured(h_single) |> only
+    @test any(x -> x isa IfOp, statements(sci1.entry.body))
+    @test ret1 === Int64
+
+    # Equivalent to explicit argtypes
+    sci2, ret2 = code_structured(h_single, Tuple{Int}) |> only
+    @test ret1 === ret2
+
+    # Multi-method function: falls back to Tuple, returns all methods
+    h_multi(x::Int) = x + 1
+    h_multi(x::Float64) = x - 1.0
+    results = code_structured(h_multi)
+    @test length(results) == 2
+end
+
 @testset "display output format" begin
     # Verify display shows proper structure
     sci, _ = code_structured(Tuple{Bool}) do x::Bool


### PR DESCRIPTION
For single-method functions, the argument types are extracted from the method signature via `default_tt`. Multi-method functions fall back to `Tuple`, returning all methods.