### PR TITLE
Fix structurization of sequential for-loops

### DIFF
--- a/src/control_tree.jl
+++ b/src/control_tree.jl
@@ -96,6 +96,14 @@ end
     all(!in(Edge(v, w), backedges) for w in outneighbors(g, v)) || return nothing
     termination_blocks = filter(w -> isempty(outneighbors(g, w)) && length(inneighbors(g, w)) == 1, outneighbors(g, v))
     isempty(termination_blocks) && return nothing
+    # Don't absorb if all remaining successors are backedge sources — that
+    # would hide the loop's only exit edge, causing downstream structurization
+    # to merge sequential loops into one.
+    remaining = filter(w -> w ∉ termination_blocks, outneighbors(g, v))
+    if !isempty(remaining)
+        backedge_sources = Set(e.src for e in backedges)
+        all(in(backedge_sources), remaining) && return nothing
+    end
     Some(termination_blocks)
 end
 

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -216,9 +216,28 @@ function build_loop_op(tree::ControlTree, ir::IRCode, ctx::StructurizationContex
     apply_substitutions!(body, subs)
 
     loop_op = LoopOp(body, init_values)
-    post_loop_blocks = sort!(collect(post_loop_set))
 
-    return loop_op, phi_indices, phi_types, post_loop_blocks
+    # Collect post-loop children: children entirely outside the natural loop,
+    # or the post-loop subtrees of mixed children (e.g., TERMINATION regions
+    # that span loop exit + post-loop code).
+    post_loop_children = ControlTree[]
+    for (i, child) in enumerate(children(tree))
+        child_blocks = child_block_cache[i]
+        if !isempty(post_loop_set) && issubset(child_blocks, post_loop_set)
+            # Entirely post-loop child — needs full structurization
+            push!(post_loop_children, child)
+        elseif !isempty(post_loop_set) && !isempty(intersect(child_blocks, post_loop_set))
+            # Mixed child — extract the post-loop subtrees
+            for sub in children(child)
+                sub_blocks = get_region_blocks(sub, ir)
+                if issubset(sub_blocks, post_loop_set)
+                    push!(post_loop_children, sub)
+                end
+            end
+        end
+    end
+
+    return loop_op, phi_indices, phi_types, post_loop_children
 end
 
 """

--- a/src/structurize/regions.jl
+++ b/src/structurize/regions.jl
@@ -241,11 +241,12 @@ end
 """
     find_extra_exit_values(ir, exit_dest, loop_blocks, already_exported) -> Vector{NamedTuple}
 
-Find loop-internal values referenced in the exit target block that are not already
+Find loop-internal values referenced outside the loop that are not already
 exported via header phis. Returns a vector of `(; value, getfield_idx, type)` tuples.
 
-Scans both PhiNodes (with edges from loop blocks) and non-phi statements whose
-Expr arguments are SSAValues defined inside the loop.
+Scans ALL blocks outside the loop (not just the exit target) because loop-internal
+values may be referenced in blocks far beyond the immediate exit — e.g., when two
+sequential for-loops share an accumulator.
 """
 function find_extra_exit_values(ir::IRCode, exit_dest::Int, loop_blocks::Set{Int},
                                 already_exported::Set{Int})
@@ -255,45 +256,65 @@ function find_extra_exit_values(ir::IRCode, exit_dest::Int, loop_blocks::Set{Int
     nblocks = length(ir.cfg.blocks)
     1 <= exit_dest <= nblocks || return extra
 
-    exit_bb = ir.cfg.blocks[exit_dest]
     seen = Set{Int}()  # track getfield_idx to avoid duplicates
 
-    for si in first(exit_bb.stmts):last(exit_bb.stmts)
-        stmt = stmts[si]
+    for blk_idx in 1:nblocks
+        blk_idx ∈ loop_blocks && continue
+        bb = ir.cfg.blocks[blk_idx]
 
-        if stmt isa PhiNode
-            si ∈ already_exported && continue
+        for si in first(bb.stmts):last(bb.stmts)
+            stmt = stmts[si]
 
-            # Find value from loop blocks
-            loop_val = nothing
-            for (edge_idx, edge) in enumerate(stmt.edges)
-                if isassigned(stmt.values, edge_idx) && edge ∈ loop_blocks
-                    loop_val = stmt.values[edge_idx]
+            if stmt isa PhiNode
+                si ∈ already_exported && continue
+
+                # Find value from loop blocks
+                loop_val = nothing
+                for (edge_idx, edge) in enumerate(stmt.edges)
+                    if isassigned(stmt.values, edge_idx) && edge ∈ loop_blocks
+                        loop_val = stmt.values[edge_idx]
+                    end
                 end
-            end
 
-            if loop_val !== nothing
-                gf_idx = loop_val isa SSAValue ? loop_val.id : si
-                gf_idx ∈ already_exported && continue
-                gf_idx ∈ seen && continue
-                push!(extra, (; value=loop_val, getfield_idx=gf_idx, type=types[si]))
-                push!(seen, gf_idx)
-            end
-        else
-            # Non-phi statement: check if any Expr arg is an SSAValue defined in loop blocks
-            stmt isa Expr || continue
-            for arg in stmt.args
-                if arg isa SSAValue && is_defined_in_blocks(arg, loop_blocks, ir)
-                    arg.id ∈ already_exported && continue
-                    arg.id ∈ seen && continue
-                    push!(extra, (; value=arg, getfield_idx=arg.id, type=types[arg.id]))
-                    push!(seen, arg.id)
+                if loop_val !== nothing
+                    gf_idx = loop_val isa SSAValue ? loop_val.id : si
+                    gf_idx ∈ seen && continue
+                    push!(extra, (; value=loop_val, getfield_idx=gf_idx, type=types[si]))
+                    push!(seen, gf_idx)
+                end
+            else
+                # Check all SSAValue references in statements outside the loop
+                for arg in _stmt_ssa_uses(stmt)
+                    if is_defined_in_blocks(arg, loop_blocks, ir)
+                        arg.id ∈ already_exported && continue
+                        arg.id ∈ seen && continue
+                        push!(extra, (; value=arg, getfield_idx=arg.id, type=types[arg.id]))
+                        push!(seen, arg.id)
+                    end
                 end
             end
         end
     end
 
     return extra
+end
+
+"""
+    _stmt_ssa_uses(stmt) -> iterator of SSAValue
+
+Extract all SSAValue references from a statement (Expr args, GotoIfNot cond,
+ReturnNode val, PhiNode values are handled separately).
+"""
+function _stmt_ssa_uses(stmt)
+    if stmt isa Expr
+        return Iterators.filter(x -> x isa SSAValue, stmt.args)
+    elseif stmt isa GotoIfNot && stmt.cond isa SSAValue
+        return (stmt.cond,)
+    elseif stmt isa ReturnNode && isdefined(stmt, :val) && stmt.val isa SSAValue
+        return (stmt.val,)
+    else
+        return ()
+    end
 end
 
 """
@@ -472,10 +493,12 @@ function handle_loop!(block::Block, tree::ControlTree, ir::IRCode,
         push!(block, iv_phi_idx, loop_op.upper, iv_type)
     end
 
-    # Emit post-loop content: blocks that were in the control tree but outside
-    # the natural loop (e.g., exit-target blocks absorbed by TERMINATION regions).
-    for blk_idx in post_loop_blocks
-        collect_block_statements!(block, blk_idx, ir)
+    # Emit post-loop content: children that were in the control tree but outside
+    # the natural loop (e.g., exit-target subtrees absorbed by TERMINATION regions).
+    # These are processed as full structured regions, not flattened blocks,
+    # because they may contain loops or other complex control flow.
+    for child in post_loop_blocks
+        process_child_region!(block, child, ir, ctx)
     end
 end
 

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -321,6 +321,88 @@ end
     end
 end
 
+@testset "sequential while loops" begin
+    sci, _ = code_structured(Tuple{Int}) do n::Int
+        # Loop 1: accumulate
+        i = 0
+        acc = 0
+        while i < n
+            acc += i
+            i += 1
+        end
+        # Loop 2: uses result from loop 1
+        j = 0
+        result = 0
+        while j < n
+            result += acc
+            j += 1
+        end
+        return result
+    end |> only
+
+    for_ops = filter(x -> x isa ForOp, collect(statements(sci.entry.body)))
+    @test length(for_ops) == 2
+end
+
+@testset "sequential for loops" begin
+    sci, _ = code_structured(Tuple{Int32}) do n::Int32
+        # Loop 1: accumulate
+        acc = Int32(0)
+        for i in Int32(1):n
+            acc += i
+        end
+        # Loop 2: uses result from loop 1
+        result = Int32(0)
+        for j in Int32(1):n
+            result += acc
+        end
+        return result
+    end |> only
+
+    all_stmts = collect(statements(sci.entry.body))
+    function count_loops(stmts)
+        n = 0
+        for s in stmts
+            if s isa LoopOp
+                n += 1
+            elseif s isa IfOp
+                n += count_loops(collect(statements(s.then_region.body)))
+                n += count_loops(collect(statements(s.else_region.body)))
+            end
+        end
+        n
+    end
+    @test count_loops(all_stmts) == 2
+end
+
+@testset "sequential for loops with constant bounds" begin
+    sci, _ = code_structured(Tuple{Vector{Float32}, Vector{Float32}, Vector{Float32}}) do a::Vector{Float32}, b::Vector{Float32}, c::Vector{Float32}
+        acc = 0.0f0
+        for i in Int32(1):Int32(2)
+            acc += a[i]
+        end
+        for i in Int32(1):Int32(2)
+            c[i] = b[i] + acc
+        end
+        return nothing
+    end |> only
+
+    all_stmts = collect(statements(sci.entry.body))
+    function count_loops(stmts)
+        n = 0
+        for s in stmts
+            if s isa LoopOp || s isa ForOp
+                n += 1
+            elseif s isa IfOp
+                n += count_loops(collect(statements(s.then_region.body)))
+                n += count_loops(collect(statements(s.else_region.body)))
+            end
+        end
+        n
+    end
+    @test count_loops(all_stmts) == 2
+end
+
 end  # ForOp detection
 
 @testset "WhileOp detection" begin


### PR DESCRIPTION
When trying to run a cuTile kernel with two for loops, I get "SSA values used but not defined" errors. With these changes it works:

1. Prevent termination_region from absorbing exit blocks when all remaining successors are backedge sources, which hid the exit edge between sequential loops.

2. Process post-loop regions as full structured children (via process_child_region!) instead of flattening them, since they may contain loops or other complex control flow.

3. Scan ALL blocks outside the loop in find_extra_exit_values, not just the immediate exit block. Loop-internal values (e.g., an accumulator) may be referenced in blocks far beyond the exit target.