### PR TITLE
Add helper to look up the type of arbitrary values.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/ir/show.jl
+++ b/src/ir/show.jl
@@ -55,7 +55,7 @@ function child_printer(p::IRPrinter, nested_block::Block, cont_prefix::String)
 end
 
 # Print region header: "├ label:" or "└ label:" for last/empty region
-function print_region_header(p::IRPrinter, label::String, args::Vector{BlockArg}; is_last::Bool=false)
+function print_region_header(p::IRPrinter, label::String, args::Vector{BlockArgument}; is_last::Bool=false)
     print_indent(p)
     print_colored(p, is_last ? "└" : "├", :light_black)
     print(p.io, " ", label)
@@ -90,7 +90,7 @@ function print_value(p::IRPrinter, v::SSAValue)
     print(p.io, "%", v.id)
 end
 
-function print_value(p::IRPrinter, v::BlockArg)
+function print_value(p::IRPrinter, v::BlockArgument)
     print(p.io, "%arg", v.id)
 end
 
@@ -123,7 +123,7 @@ end
 function format_value(p::IRPrinter, v::SSAValue)
     string("%", v.id)
 end
-function format_value(p::IRPrinter, v::BlockArg)
+function format_value(p::IRPrinter, v::BlockArgument)
     string("%arg", v.id)
 end
 function format_value(p::IRPrinter, v::Argument)
@@ -243,7 +243,7 @@ function print_expr(p::IRPrinter, v)
 end
 
 # Print block arguments (for loops and structured control flow)
-function print_block_args(p::IRPrinter, args::Vector{BlockArg})
+function print_block_args(p::IRPrinter, args::Vector{BlockArgument})
     if isempty(args)
         return
     end
@@ -258,14 +258,14 @@ function print_block_args(p::IRPrinter, args::Vector{BlockArg})
 end
 
 # Print initial values (carries) with their types
-function print_init_values(p::IRPrinter, carry_args::Vector{BlockArg}, init_values::Vector{IRValue})
+function print_init_values(p::IRPrinter, carry_args::Vector{BlockArgument}, init_values::Vector{IRValue})
     if isempty(carry_args)
         return
     end
     print(p.io, " init(")
     for (i, (arg, init)) in enumerate(zip(carry_args, init_values))
         i > 1 && print(p.io, ", ")
-        # Use same naming as BlockArg print_value for consistency
+        # Use same naming as BlockArgument print_value for consistency
         print(p.io, "%arg", arg.id, " = ")
         print_value(p, init)
         print_colored(p, string("::", format_type(arg.type)), :cyan)
@@ -273,7 +273,7 @@ function print_init_values(p::IRPrinter, carry_args::Vector{BlockArg}, init_valu
     print(p.io, ")")
 end
 
-function print_loop_args(p::IRPrinter, block_args::Vector{BlockArg}, init_values::Vector{IRValue})
+function print_loop_args(p::IRPrinter, block_args::Vector{BlockArgument}, init_values::Vector{IRValue})
     print_init_values(p, block_args, init_values)
 end
 

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -1,6 +1,6 @@
 # structured IR definitions
 
-export StructuredIRCode, Undef, Inst, instructions, arguments, value_type, stmt,
+export StructuredIRCode, Undef, Instruction, instructions, arguments, value_type, stmt,
        insert_before!, insert_after!, terminator, terminator!, operands
 
 #=============================================================================
@@ -8,12 +8,12 @@ export StructuredIRCode, Undef, Inst, instructions, arguments, value_type, stmt,
 =============================================================================#
 
 """
-    BlockArg
+    BlockArgument
 
 Represents a block argument (similar to MLIR block arguments).
 Used for loop carried values and condition branch results.
 """
-struct BlockArg
+struct BlockArgument
     id::Int
     type::Any  # Julia type
 end
@@ -44,43 +44,46 @@ Base.show(io::IO, u::Undef) = print(io, "undef::$(u.type)")
 
 # IRValue: Values used in structured IR
 # - SSAValue, Argument, SlotNumber: references to Julia IR values
-# - BlockArg: block arguments for control flow
+# - BlockArgument: block arguments for control flow
 # - Undef: structurization artifact for dead branches
 # - Raw values (Integer, Float, etc.): compile-time constants
 const IRValue = Any
 
 #=============================================================================
- Inst - instruction bundling SSA index + statement + type
+ Instruction - convenience view over an SSAMap entry
 =============================================================================#
 
 """
-    Inst
+    Instruction
 
-An instruction in the structured IR, bundling an SSA index with its statement
-and type. Analogous to LLVM's `Instruction` which IS a `Value` carrying its type.
+A convenience view over an SSAMap entry, bundling an SSA index with its statement
+and type. Yielded by `instructions(block)` and usable as a key in `UseIndex`.
 
-Yielded by `instructions(block)`. Can be used as a key in `UseIndex`.
+Unlike the structural IR elements (`SSAValue`, `BlockArgument`, `Argument`) which appear
+as operands in the IR, an `Instruction` is constructed on-the-fly during iteration
+and provides convenient access to all three aspects of a definition: its identity
+(`ssa_idx`), its statement (`stmt`), and its Julia type (`typ`).
 """
-struct Inst
+struct Instruction
     ssa_idx::Int
     stmt::Any
     typ::Any
 end
 
 """Get the Julia type of the instruction result."""
-value_type(i::Inst) = i.typ
+value_type(i::Instruction) = i.typ
 
 """Get the underlying statement (Expr, ControlFlowOp, etc.)."""
-stmt(i::Inst) = i.stmt
+stmt(i::Instruction) = i.stmt
 
 """Convert to SSAValue for use in operand positions."""
-Core.SSAValue(i::Inst) = SSAValue(i.ssa_idx)
+Core.SSAValue(i::Instruction) = SSAValue(i.ssa_idx)
 
-Base.:(==)(a::Inst, b::Inst) = a.ssa_idx == b.ssa_idx
-Base.hash(i::Inst, h::UInt) = hash(i.ssa_idx, h)
+Base.:(==)(a::Instruction, b::Instruction) = a.ssa_idx == b.ssa_idx
+Base.hash(i::Instruction, h::UInt) = hash(i.ssa_idx, h)
 
-function Base.show(io::IO, i::Inst)
-    print(io, "Inst(%$(i.ssa_idx)")
+function Base.show(io::IO, i::Instruction)
+    print(io, "Instruction(%$(i.ssa_idx)")
     if i.stmt isa ControlFlowOp
         print(io, " = ", typeof(i.stmt))
     elseif i.stmt isa Expr
@@ -254,13 +257,13 @@ A block of statements with block arguments and a terminator.
 Body is an SSAMap mapping SSA indices to (stmt, type) entries.
 """
 mutable struct Block
-    args::Vector{BlockArg}
+    args::Vector{BlockArgument}
     body::SSAMap
     terminator::Terminator
     parent::Any  # containing Block, or StructuredIRCode for entry block, or nothing
 end
 
-Block() = Block(BlockArg[], SSAMap(), nothing, nothing)
+Block() = Block(BlockArgument[], SSAMap(), nothing, nothing)
 
 """
     push!(block::Block, idx::Int, stmt, typ)
@@ -301,8 +304,8 @@ Base.eltype(::Type{Block}) = Tuple{Int,Any,Any}
 """
     instructions(block::Block)
 
-Iterate over the instructions in a block, yielding `Inst` objects.
-Each `Inst` bundles the SSA index, statement, and type — users never
+Iterate over the instructions in a block, yielding `Instruction` objects.
+Each `Instruction` bundles the SSA index, statement, and type — users never
 need to interact with SSAMap directly.
 
 Analogous to LLVM.jl's `instructions(bb::BasicBlock)`.
@@ -314,17 +317,17 @@ struct InstructionIterator
 end
 
 Base.length(it::InstructionIterator) = length(it.body)
-Base.eltype(::Type{InstructionIterator}) = Inst
+Base.eltype(::Type{InstructionIterator}) = Instruction
 
 function Base.iterate(it::InstructionIterator, state::Int=1)
     m = it.body
     state > length(m.ssa_idxes) && return nothing
-    inst = Inst(m.ssa_idxes[state], m.stmts[state], m.types[state])
+    inst = Instruction(m.ssa_idxes[state], m.stmts[state], m.types[state])
     return inst, state + 1
 end
 
 """
-    arguments(block::Block) -> Vector{BlockArg}
+    arguments(block::Block) -> Vector{BlockArgument}
 
 Get the block arguments. Analogous to LLVM.jl's `parameters(f)`.
 """
@@ -386,7 +389,7 @@ mutable struct ForOp <: ControlFlowOp
     lower::IRValue
     upper::IRValue
     step::IRValue
-    iv_arg::BlockArg
+    iv_arg::BlockArgument
     body::Block
     init_values::Vector{IRValue}
 end

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -38,14 +38,14 @@ function root(block::Block)
     return p::StructuredIRCode
 end
 
-"""Delete an instruction from a block by `Inst`."""
-function Base.delete!(block::Block, inst::Inst)
+"""Delete an instruction from a block by `Instruction`."""
+function Base.delete!(block::Block, inst::Instruction)
     delete!(block.body, inst.ssa_idx)
     return block
 end
 
 """
-    push!(block::Block, stmt, typ) -> Inst
+    push!(block::Block, stmt, typ) -> Instruction
 
 Append a new instruction to the block, auto-allocating an SSA index.
 Requires `block.parent` to be set (see `_set_parent!`).
@@ -60,11 +60,11 @@ function Base.push!(block::Block, @nospecialize(stmt), @nospecialize(typ))
             b.parent = block
         end
     end
-    return Inst(idx, stmt, typ)
+    return Instruction(idx, stmt, typ)
 end
 
 """
-    pushfirst!(block::Block, stmt, typ) -> Inst
+    pushfirst!(block::Block, stmt, typ) -> Instruction
 
 Prepend a new instruction at the beginning of the block, auto-allocating an SSA index.
 """
@@ -80,15 +80,15 @@ function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(typ))
             b.parent = block
         end
     end
-    return Inst(idx, stmt, typ)
+    return Instruction(idx, stmt, typ)
 end
 
 """
-    update_type!(block::Block, inst::Inst, new_type)
+    update_type!(block::Block, inst::Instruction, new_type)
 
 Update the type annotation for an existing instruction.
 """
-function update_type!(block::Block, inst::Inst, @nospecialize(new_type))
+function update_type!(block::Block, inst::Instruction, @nospecialize(new_type))
     pos = findfirst(==(inst.ssa_idx), block.body.ssa_idxes)
     pos === nothing && throw(KeyError(inst.ssa_idx))
     block.body.types[pos] = new_type
@@ -96,29 +96,66 @@ function update_type!(block::Block, inst::Inst, @nospecialize(new_type))
 end
 
 """
-    new_block_arg!(block::Block, typ) -> BlockArg
+    value_type(block::Block, val) -> Any
 
-Add a new BlockArg to a block, allocating a fresh ID from the root StructuredIRCode.
+Get the Julia type of an arbitrary IR value as visible from `block`.
+
+For `SSAValue`, searches the current block then walks up the parent chain.
+For `BlockArgument` and `Undef`, returns the type stored on the value.
+For `Argument`/`SlotNumber`, looks up in the root `StructuredIRCode.argtypes`.
+For constants, returns `typeof(val)`.
+Returns `nothing` only for an `SSAValue` or `Argument` whose type cannot be found.
+"""
+function value_type(block::Block, @nospecialize(val))
+    if val isa SSAValue
+        entry = get(block.body, val.id, nothing)
+        entry !== nothing && return entry.typ
+        p = block.parent
+        while p isa Block
+            entry = get(p.body, val.id, nothing)
+            entry !== nothing && return entry.typ
+            p = p.parent
+        end
+        return nothing
+    elseif val isa BlockArgument
+        return val.type
+    elseif val isa Undef
+        return val.type
+    elseif val isa Argument
+        sci = root(block)
+        return val.n <= length(sci.argtypes) ? sci.argtypes[val.n] : nothing
+    elseif val isa SlotNumber
+        sci = root(block)
+        return val.id <= length(sci.argtypes) ? sci.argtypes[val.id] : nothing
+    else
+        return typeof(val)  # constant
+    end
+end
+
+"""
+    new_block_arg!(block::Block, typ) -> BlockArgument
+
+Add a new BlockArgument to a block, allocating a fresh ID from the root StructuredIRCode.
 """
 function new_block_arg!(block::Block, @nospecialize(typ))
     sci = root(block)
     sci.max_ssa_idx += 1
-    arg = BlockArg(sci.max_ssa_idx, typ)
+    arg = BlockArgument(sci.max_ssa_idx, typ)
     push!(block.args, arg)
     return arg
 end
 
 """
-    insert_before!(block::Block, ref::Inst, stmt, typ) -> Inst
+    insert_before!(block::Block, ref::Instruction, stmt, typ) -> Instruction
 
 Insert a new instruction before `ref`, auto-allocating an SSA index.
 """
-function insert_before!(block::Block, ref::Inst, @nospecialize(stmt), @nospecialize(typ))
+function insert_before!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     insert_before_idx!(block.body, ref.ssa_idx, idx, stmt, typ)
-    return Inst(idx, stmt, typ)
+    return Instruction(idx, stmt, typ)
 end
 
 function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, typ)
@@ -130,16 +167,16 @@ function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, typ)
 end
 
 """
-    insert_after!(block::Block, ref::Inst, stmt, typ) -> Inst
+    insert_after!(block::Block, ref::Instruction, stmt, typ) -> Instruction
 
 Insert a new instruction after `ref`, auto-allocating an SSA index.
 """
-function insert_after!(block::Block, ref::Inst, @nospecialize(stmt), @nospecialize(typ))
+function insert_after!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     insert_after_idx!(block.body, ref.ssa_idx, idx, stmt, typ)
-    return Inst(idx, stmt, typ)
+    return Instruction(idx, stmt, typ)
 end
 
 function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, typ)
@@ -151,7 +188,7 @@ function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, typ)
 end
 
 """
-    insert_before!(block::Block, ref::SSAValue, stmt, typ) -> Inst
+    insert_before!(block::Block, ref::SSAValue, stmt, typ) -> Instruction
 
 Insert a new instruction before the instruction at SSA index `ref.id`.
 """
@@ -165,11 +202,11 @@ function insert_before!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospe
             b.parent = block
         end
     end
-    return Inst(idx, stmt, typ)
+    return Instruction(idx, stmt, typ)
 end
 
 """
-    insert_after!(block::Block, ref::SSAValue, stmt, typ) -> Inst
+    insert_after!(block::Block, ref::SSAValue, stmt, typ) -> Instruction
 
 Insert a new instruction after the instruction at SSA index `ref.id`.
 """
@@ -183,7 +220,7 @@ function insert_after!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospec
             b.parent = block
         end
     end
-    return Inst(idx, stmt, typ)
+    return Instruction(idx, stmt, typ)
 end
 
 
@@ -351,7 +388,7 @@ Pre-built index mapping values to their use sites. Created by `uses(block)`.
 Supports `idx[val]` to get use sites, `haskey(idx, val)` for liveness checks.
 
 Accepts any key type that appears in operand positions: `Int` (treated as
-SSAValue index), `SSAValue`, `BlockArg`, `Argument`, etc.
+SSAValue index), `SSAValue`, `BlockArgument`, `Argument`, etc.
 """
 struct UseIndex
     index::Dict{Any, Vector{UseRef}}
@@ -364,10 +401,10 @@ end
 
 Base.haskey(idx::UseIndex, @nospecialize(key)) = haskey(idx.index, normalize_key(key))
 
-# Normalize keys so that SSAValue(5), plain Int 5, and Inst(5,...) map to the same entry
+# Normalize keys so that SSAValue(5), plain Int 5, and Instruction(5,...) map to the same entry
 normalize_key(v::SSAValue) = v
 normalize_key(v::Int) = SSAValue(v)
-normalize_key(v::Inst) = SSAValue(v.ssa_idx)
+normalize_key(v::Instruction) = SSAValue(v.ssa_idx)
 normalize_key(@nospecialize(v)) = v
 
 
@@ -415,7 +452,7 @@ end
     replace_uses!(block::Block, old, new_val)
 
 Replace all uses of `old` with `new_val` in `block` (recursively).
-`old` can be any value type (SSAValue, BlockArg, Inst, Int).
+`old` can be any value type (SSAValue, BlockArgument, Instruction, Int).
 """
 function replace_uses!(block::Block, @nospecialize(old), @nospecialize(new_val))
     target = normalize_key(old)
@@ -523,14 +560,14 @@ body_block(op::WhileOp) = op.before  # carries enter through before block
 """Get the init value for this carry."""
 init_value(c::CarryRef) = c.carries.op.init_values[c.index]
 
-"""Get the body BlockArg for this carry."""
+"""Get the body BlockArgument for this carry."""
 function body_arg(c::CarryRef)
     op = c.carries.op
     block = body_block(op)
     block.args[c.index]
 end
 
-"""Get the after-region BlockArg for this carry (WhileOp only)."""
+"""Get the after-region BlockArgument for this carry (WhileOp only)."""
 after_arg(c::CarryRef) = (c.carries.op::WhileOp).after.args[c.index]
 
 """Get the terminator value for this carry from a specific terminator."""
@@ -630,7 +667,7 @@ end
 """
     push!(carries::LoopCarries, init_val, body_arg_type) -> CarryRef
 
-Append a new carry to the loop. Creates a new BlockArg for the body,
+Append a new carry to the loop. Creates a new BlockArgument for the body,
 pushes init_val, and threads the new arg through all reachable terminators.
 
 Returns a CarryRef to the new carry.
@@ -733,12 +770,12 @@ function _collect_blocks!(out, block::Block)
 end
 
 """
-    findblock(sci::StructuredIRCode, inst::Inst) -> Union{Block, Nothing}
+    findblock(sci::StructuredIRCode, inst::Instruction) -> Union{Block, Nothing}
 
 Find the Block containing the given instruction.
 Returns `nothing` if not found.
 """
-function findblock(sci::StructuredIRCode, inst::Inst)
+function findblock(sci::StructuredIRCode, inst::Instruction)
     found = nothing
     walk(sci) do i, block
         if i.ssa_idx == inst.ssa_idx
@@ -837,11 +874,11 @@ function resolve_call(@nospecialize(stmt))
 end
 
 """
-    resolve_call(inst::Inst) -> (resolved_func, operands) or nothing
+    resolve_call(inst::Instruction) -> (resolved_func, operands) or nothing
 
-Convenience overload: extracts the statement from an `Inst`.
+Convenience overload: extracts the statement from an `Instruction`.
 """
-resolve_call(inst::Inst) = resolve_call(inst.stmt)
+resolve_call(inst::Instruction) = resolve_call(inst.stmt)
 
 """
     iscall(stmt) -> Bool
@@ -851,11 +888,11 @@ Check whether a statement is a `:call` or `:invoke` expression.
 iscall(@nospecialize(stmt)) = stmt isa Expr && (stmt.head === :call || stmt.head === :invoke)
 
 """
-    iscall(inst::Inst) -> Bool
+    iscall(inst::Instruction) -> Bool
 
 Convenience overload: checks the underlying statement.
 """
-iscall(inst::Inst) = iscall(inst.stmt)
+iscall(inst::Instruction) = iscall(inst.stmt)
 
 """
     callee(stmt::Expr) -> Any
@@ -874,11 +911,11 @@ function callee(stmt::Expr)
 end
 
 """
-    callee(inst::Inst) -> Any
+    callee(inst::Instruction) -> Any
 
 Convenience overload: extracts callee from the underlying statement.
 """
-callee(inst::Inst) = callee(inst.stmt::Expr)
+callee(inst::Instruction) = callee(inst.stmt::Expr)
 
 """
     callargs(stmt::Expr) -> SubArray
@@ -896,8 +933,8 @@ function callargs(stmt::Expr)
 end
 
 """
-    callargs(inst::Inst) -> SubArray
+    callargs(inst::Instruction) -> SubArray
 
 Convenience overload: extracts call arguments from the underlying statement.
 """
-callargs(inst::Inst) = callargs(inst.stmt::Expr)
+callargs(inst::Instruction) = callargs(inst.stmt::Expr)

--- a/src/ir/validation.jl
+++ b/src/ir/validation.jl
@@ -46,7 +46,7 @@ end
 """
     validate_no_phis(entry::Block) -> Bool
 
-Validate that all phi nodes have been converted to BlockArgs.
+Validate that all phi nodes have been converted to BlockArguments.
 Errors if PhiNode expressions remain (indicates a bug in structurization).
 """
 function validate_no_phis(entry::Block)
@@ -397,7 +397,7 @@ function resolve_type end
 
 resolve_type(sci::StructuredIRCode, value::Undef) = value.type
 
-resolve_type(sci::StructuredIRCode, value::BlockArg) = value.type
+resolve_type(sci::StructuredIRCode, value::BlockArgument) = value.type
 
 resolve_type(sci::StructuredIRCode, value::Argument) = sci.argtypes[value.n]
 

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -56,12 +56,12 @@ function build_while_op(tree::ControlTree, ir::IRCode, ctx::StructurizationConte
     collect_loop_body_stmts!(after, tree, header_idx, ir, ctx)
     after.terminator = YieldOp(copy(carried_values))
 
-    # Create BlockArgs and apply substitutions immediately
+    # Create BlockArguments and apply substitutions immediately
     subs = Substitutions()
     for (i, (phi_idx, phi_type)) in enumerate(zip(phi_indices, phi_types))
-        arg = BlockArg(i, phi_type)
+        arg = BlockArgument(i, phi_type)
         push!(before.args, arg)
-        push!(after.args, BlockArg(i, phi_type))
+        push!(after.args, BlockArgument(i, phi_type))
         subs[phi_idx] = arg
     end
     apply_substitutions!(before, subs)
@@ -175,13 +175,13 @@ function build_loop_op(tree::ControlTree, ir::IRCode, ctx::StructurizationContex
         process_child_region!(target, child, ir, ctx)
     end
 
-    # 5. BlockArgs for header phis + substitutions
+    # 5. BlockArguments for header phis + substitutions
     # NOTE: must happen before pad_extra_exits! so body.args order matches
     # init_values/carried_values order (header phis first, then extra exits).
     n_header_phis = length(phi_indices)
     subs = Substitutions()
     for (i, (phi_idx, phi_type)) in enumerate(zip(phi_indices[1:n_header_phis], phi_types))
-        arg = BlockArg(i, phi_type)
+        arg = BlockArgument(i, phi_type)
         push!(body.args, arg)
         subs[phi_idx] = arg
     end
@@ -235,7 +235,7 @@ The ForOp structure:
 - lower: Lower bound from ForLoopInfo
 - upper: Exclusive upper bound (adjusted +1 for inclusive patterns like `<=`)
 - step: Step value from ForLoopInfo
-- iv_arg: BlockArg for the induction variable
+- iv_arg: BlockArgument for the induction variable
 - body: Loop body statements + ContinueOp with carried values
 - init_values: Non-IV loop-carried values
 """
@@ -269,8 +269,8 @@ function build_for_op(block::Block, tree::ControlTree, ir::IRCode, ctx::Structur
     # Get IV type
     iv_type = types[iv_phi_idx]
 
-    # Create BlockArg for IV (id=1, first in ForOp's block args)
-    iv_arg = BlockArg(1, iv_type)
+    # Create BlockArgument for IV (id=1, first in ForOp's block args)
+    iv_arg = BlockArgument(1, iv_type)
 
     # Build the body block
     body = Block()
@@ -308,13 +308,13 @@ function build_for_op(block::Block, tree::ControlTree, ir::IRCode, ctx::Structur
     end
     n_phi = length(phi_indices)
 
-    # Create BlockArgs for header phis BEFORE padding extra exits,
+    # Create BlockArguments for header phis BEFORE padding extra exits,
     # so body.args order matches init_values/carried_values order
     # (header phis first, then extra exits).
     subs = Substitutions()
     subs[iv_phi_idx] = iv_arg  # IV at index 1
     for (i, (phi_idx, phi_type)) in enumerate(zip(phi_indices[1:n_phi], phi_types))
-        arg = BlockArg(i + 1, phi_type)
+        arg = BlockArgument(i + 1, phi_type)
         push!(body.args, arg)
         subs[phi_idx] = arg
     end

--- a/src/structurize/regions.jl
+++ b/src/structurize/regions.jl
@@ -301,13 +301,13 @@ end
 
 Pad extra exit values into the loop-carry chain and append to phi tracking vectors.
 Each extra exit value becomes a loop-carried variable with `Undef` initial value.
-`arg_offset` is the starting BlockArg id for the new args.
+`arg_offset` is the starting BlockArgument id for the new args.
 """
 function pad_extra_exits!(extra_exits, init_values, carried_values, body, phi_indices, phi_types, arg_offset::Int)
     for (j, ex) in enumerate(extra_exits)
         push!(init_values, Undef(ex.type))
         push!(carried_values, ex.value)
-        push!(body.args, BlockArg(arg_offset + j, ex.type))
+        push!(body.args, BlockArgument(arg_offset + j, ex.type))
     end
     for ex in extra_exits
         push!(phi_indices, ex.getfield_idx)

--- a/src/structurize/substitutions.jl
+++ b/src/structurize/substitutions.jl
@@ -23,15 +23,15 @@ end
 """
     Substitutions
 
-A mapping from SSA value indices to BlockArgs.
+A mapping from SSA value indices to BlockArguments.
 Used during IR construction to replace phi node references with block arguments.
 """
-const Substitutions = Dict{Int, BlockArg}
+const Substitutions = Dict{Int, BlockArgument}
 
 """
     substitute_ssa(value, subs::Substitutions)
 
-Recursively substitute SSAValues with BlockArgs according to the substitution map.
+Recursively substitute SSAValues with BlockArguments according to the substitution map.
 Used to convert phi node references to block argument references inside loop bodies.
 """
 function substitute_ssa(value, subs::Substitutions)
@@ -60,7 +60,7 @@ end
 substitute_ssa(value) = value
 
 #=============================================================================
- Block Substitution (apply SSA → BlockArg mappings)
+ Block Substitution (apply SSA → BlockArgument mappings)
 =============================================================================#
 
 """
@@ -105,13 +105,13 @@ function apply_substitutions!(op::ForOp, subs::Substitutions)
         op.init_values[j] = substitute_ssa(v, subs)
     end
 
-    # Thread outer BlockArgs through inner loop as invariant carries.
-    # Without this, an outer BlockArg(1) collides with the inner loop's own BlockArg(1) (its IV).
+    # Thread outer BlockArguments through inner loop as invariant carries.
+    # Without this, an outer BlockArgument(1) collides with the inner loop's own BlockArgument(1) (its IV).
     isempty(subs) && return
     inner_subs = Substitutions()
     for (ssa_idx, outer_arg) in subs
         next_id = isempty(op.body.args) ? 2 : maximum(a.id for a in op.body.args) + 1
-        inner_arg = BlockArg(next_id, outer_arg.type)
+        inner_arg = BlockArgument(next_id, outer_arg.type)
         push!(op.body.args, inner_arg)
         push!(op.init_values, outer_arg)
         if op.body.terminator isa ContinueOp
@@ -131,7 +131,7 @@ function apply_substitutions!(op::LoopOp, subs::Substitutions)
     inner_subs = Substitutions()
     for (ssa_idx, outer_arg) in subs
         next_id = isempty(op.body.args) ? 1 : maximum(a.id for a in op.body.args) + 1
-        inner_arg = BlockArg(next_id, outer_arg.type)
+        inner_arg = BlockArgument(next_id, outer_arg.type)
         push!(op.body.args, inner_arg)
         push!(op.init_values, outer_arg)
         _thread_loop_carry!(op.body, inner_arg)
@@ -146,7 +146,7 @@ end
 Push `inner_arg` to every ContinueOp and BreakOp terminator reachable from `block`,
 recursing into nested IfOps (but not into nested loop ops, which have their own scopes).
 """
-function _thread_loop_carry!(block::Block, inner_arg::BlockArg)
+function _thread_loop_carry!(block::Block, inner_arg::BlockArgument)
     if block.terminator isa ContinueOp
         push!(block.terminator.values, inner_arg)
     elseif block.terminator isa BreakOp
@@ -171,7 +171,7 @@ function apply_substitutions!(op::WhileOp, subs::Substitutions)
     for (ssa_idx, outer_arg) in subs
         # before region
         next_before_id = isempty(op.before.args) ? 1 : maximum(a.id for a in op.before.args) + 1
-        before_arg = BlockArg(next_before_id, outer_arg.type)
+        before_arg = BlockArgument(next_before_id, outer_arg.type)
         push!(op.before.args, before_arg)
         push!(op.init_values, outer_arg)
         if op.before.terminator isa ConditionOp
@@ -180,7 +180,7 @@ function apply_substitutions!(op::WhileOp, subs::Substitutions)
 
         # after region
         next_after_id = isempty(op.after.args) ? 1 : maximum(a.id for a in op.after.args) + 1
-        after_arg = BlockArg(next_after_id, outer_arg.type)
+        after_arg = BlockArgument(next_after_id, outer_arg.type)
         push!(op.after.args, after_arg)
         if op.after.terminator isa YieldOp
             push!(op.after.terminator.values, after_arg)

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -12,9 +12,9 @@
 
     insts = collect(instructions(sci.entry))
     @test !isempty(insts)
-    @test all(i -> i isa Inst, insts)
+    @test all(i -> i isa Instruction, insts)
 
-    # Each Inst bundles ssa_idx, stmt, typ
+    # Each Instruction bundles ssa_idx, stmt, typ
     inst = first(insts)
     @test value_type(inst) isa Type
     @test SSAValue(inst) isa SSAValue
@@ -39,7 +39,7 @@ end
         if stmt(inst) isa ForOp
             body_args = arguments(stmt(inst).body)
             @test !isempty(body_args)
-            @test all(a -> a isa BlockArg, body_args)
+            @test all(a -> a isa BlockArgument, body_args)
             break
         end
     end
@@ -129,9 +129,9 @@ end  # types & accessors
 
     old_max = sci.max_ssa_idx
 
-    # push! returns Inst with auto-allocated SSA
+    # push! returns Instruction with auto-allocated SSA
     new_inst = push!(sci.entry, Expr(:call, :dummy), Int)
-    @test new_inst isa Inst
+    @test new_inst isa Instruction
     @test new_inst.ssa_idx == old_max + 1
     @test sci.max_ssa_idx == old_max + 1
 
@@ -140,7 +140,7 @@ end  # types & accessors
     ref = first(insts)
     before = insert_before!(sci.entry, ref, Expr(:call, :before), Int32)
     after = insert_after!(sci.entry, ref, Expr(:call, :after), Int64)
-    @test before isa Inst && after isa Inst
+    @test before isa Instruction && after isa Instruction
 
     all_insts = collect(instructions(sci.entry))
     bp = findfirst(i -> i == before, all_insts)
@@ -156,7 +156,7 @@ end
 
     old_first = first(instructions(sci.entry))
     new_inst = pushfirst!(sci.entry, Expr(:call, :sentinel), Int)
-    @test new_inst isa Inst
+    @test new_inst isa Instruction
     @test first(instructions(sci.entry)) == new_inst
     @test collect(instructions(sci.entry))[2] == old_first
 end
@@ -204,7 +204,7 @@ end
 
         old_n = length(arguments(op.body))
         new_arg = new_block_arg!(op.body, Float32)
-        @test new_arg isa BlockArg
+        @test new_arg isa BlockArgument
         @test new_arg.type == Float32
         @test length(arguments(op.body)) == old_n + 1
         @test arguments(op.body)[end] === new_arg
@@ -223,11 +223,11 @@ end
 
     # insert_before! with SSAValue reference
     before = insert_before!(sci.entry, ref_ssaval, Expr(:call, :before_ssa), Int32)
-    @test before isa Inst
+    @test before isa Instruction
 
     # insert_after! with SSAValue reference
     after = insert_after!(sci.entry, ref_ssaval, Expr(:call, :after_ssa), Int64)
-    @test after isa Inst
+    @test after isa Instruction
 
     # Verify ordering: before < ref < after
     all_insts = collect(instructions(sci.entry))
@@ -249,7 +249,7 @@ end
         x + 1
     end |> only
 
-    bad_ref = Inst(999999, nothing, Nothing)
+    bad_ref = Instruction(999999, nothing, Nothing)
     @test_throws KeyError insert_before!(sci.entry, bad_ref, Expr(:call, :x), Int)
 end
 
@@ -305,7 +305,7 @@ end
     @test found === sci.entry
 
     # Non-existent instruction returns nothing
-    @test findblock(sci, Inst(999999, nothing, Nothing)) === nothing
+    @test findblock(sci, Instruction(999999, nothing, Nothing)) === nothing
 end
 
 @testset "reachable_terminators(block)" begin
@@ -338,7 +338,7 @@ end
     else_blk.terminator = YieldOp(Any[SSAValue(31)])
 
     body = Block()
-    a1 = BlockArg(1, Int)
+    a1 = BlockArgument(1, Int)
     push!(body.args, a1)
     ifop = IfOp(SSAValue(1), then_blk, else_blk)
     push!(body.body, (10, ifop, Int))
@@ -360,7 +360,7 @@ end
     else_blk.terminator = YieldOp(Any[SSAValue(31)])
 
     body = Block()
-    a1 = BlockArg(1, Int)
+    a1 = BlockArgument(1, Int)
     push!(body.args, a1)
     ifop = IfOp(SSAValue(1), then_blk, else_blk)
     push!(body.body, (10, ifop, Int))
@@ -398,7 +398,7 @@ end
     sci, _ = code_structured(x -> x > 0 ? x + 1 : x - 1, Tuple{Int}) |> only
 
     # Preorder: collect all instructions
-    pre_insts = Inst[]
+    pre_insts = Instruction[]
     walk(sci) do inst, block
         push!(pre_insts, inst)
         return :advance
@@ -406,7 +406,7 @@ end
     @test !isempty(pre_insts)
 
     # Postorder: collect all instructions
-    post_insts = Inst[]
+    post_insts = Instruction[]
     walk(sci; order=:postorder) do inst, block
         push!(post_insts, inst)
         return :advance
@@ -417,7 +417,7 @@ end
     # In preorder, the IfOp should come before instructions inside it
     ifop_idx = findfirst(i -> stmt(i) isa IfOp, pre_insts)
     @test ifop_idx !== nothing
-    # Instructions after the IfOp in preorder should include nested ones
+    # Instructionructions after the IfOp in preorder should include nested ones
     @test length(pre_insts) > ifop_idx
 
     # In postorder, the IfOp should come after instructions inside it
@@ -425,7 +425,7 @@ end
     @test ifop_idx_post > 1  # nested instructions come first
 
     # Skip: don't recurse into IfOp
-    skip_insts = Inst[]
+    skip_insts = Instruction[]
     walk(sci) do inst, block
         push!(skip_insts, inst)
         stmt(inst) isa IfOp && return :skip
@@ -434,7 +434,7 @@ end
     @test length(skip_insts) < length(pre_insts)
 
     # Interrupt: stop after first instruction
-    first_only = Inst[]
+    first_only = Instruction[]
     walk(sci) do inst, block
         push!(first_only, inst)
         return :interrupt
@@ -442,7 +442,7 @@ end
     @test length(first_only) == 1
 
     # Nothing return treated as :advance
-    nothing_insts = Inst[]
+    nothing_insts = Instruction[]
     walk(sci) do inst, block
         push!(nothing_insts, inst)
         nothing
@@ -622,7 +622,7 @@ end  # use tracking
         # Access through carries
         cr = c[1]
         @test init_value(cr) !== nothing
-        @test body_arg(cr) isa BlockArg
+        @test body_arg(cr) isa BlockArgument
         found = true
         break
     end
@@ -632,9 +632,9 @@ end
 @testset "carries filter!" begin
     # Build a ForOp with 2 carries, filter to keep only the first
     body = Block()
-    iv = BlockArg(1, Int)
-    a1 = BlockArg(2, Float64)
-    a2 = BlockArg(3, Float64)
+    iv = BlockArgument(1, Int)
+    a1 = BlockArgument(2, Float64)
+    a2 = BlockArgument(3, Float64)
     # ForOp: IV is in iv_arg, body.args are just the carries
     push!(body.args, a1)
     push!(body.args, a2)
@@ -653,7 +653,7 @@ end
 
 @testset "carries push!" begin
     entry = Block()
-    iv = BlockArg(1, Int)
+    iv = BlockArgument(1, Int)
     body = Block()
     body.terminator = ContinueOp(IRStructurizer.IRValue[])
     op = ForOp(1, 10, 1, iv, body, IRStructurizer.IRValue[])
@@ -675,10 +675,10 @@ end
 
 @testset "deleteat!(carries, indices)" begin
     body = Block()
-    iv = BlockArg(1, Int)
-    a1 = BlockArg(2, Float64)
-    a2 = BlockArg(3, Float64)
-    a3 = BlockArg(4, Float64)
+    iv = BlockArgument(1, Int)
+    a1 = BlockArgument(2, Float64)
+    a2 = BlockArgument(3, Float64)
+    a3 = BlockArgument(4, Float64)
     push!(body.args, a1)
     push!(body.args, a2)
     push!(body.args, a3)
@@ -697,8 +697,8 @@ end
 
 @testset "init_value! and term_value! setters" begin
     body = Block()
-    iv = BlockArg(1, Int)
-    a1 = BlockArg(2, Float64)
+    iv = BlockArgument(1, Int)
+    a1 = BlockArgument(2, Float64)
     push!(body.args, a1)
     body.terminator = ContinueOp(Any[SSAValue(10)])
     op = ForOp(1, 10, 1, iv, body, Any[SSAValue(100)])
@@ -728,7 +728,7 @@ end
     else_blk.terminator = YieldOp(Any[SSAValue(31)])
 
     body = Block()
-    a1 = BlockArg(1, Int)
+    a1 = BlockArgument(1, Int)
     push!(body.args, a1)
     ifop = IfOp(SSAValue(1), then_blk, else_blk)
     push!(body.body, (10, ifop, Int))
@@ -758,14 +758,14 @@ end
 @testset "carries for WhileOp" begin
     before = Block()
     after = Block()
-    a1_before = BlockArg(1, Int)
-    a2_before = BlockArg(2, Float64)
+    a1_before = BlockArgument(1, Int)
+    a2_before = BlockArgument(2, Float64)
     push!(before.args, a1_before)
     push!(before.args, a2_before)
     before.terminator = ConditionOp(SSAValue(1), Any[a1_before, a2_before])
 
-    a1_after = BlockArg(1, Int)
-    a2_after = BlockArg(2, Float64)
+    a1_after = BlockArgument(1, Int)
+    a2_after = BlockArgument(2, Float64)
     push!(after.args, a1_after)
     push!(after.args, a2_after)
     after.terminator = YieldOp(Any[SSAValue(20), SSAValue(21)])
@@ -798,7 +798,7 @@ end
     else_blk.terminator = ContinueOp(Any[SSAValue(60)])
 
     body = Block()
-    a1 = BlockArg(1, Int)
+    a1 = BlockArgument(1, Int)
     push!(body.args, a1)
     ifop = IfOp(SSAValue(1), then_blk, else_blk)
     push!(body.body, (10, ifop, Nothing))
@@ -830,8 +830,8 @@ end
     # Build a WhileOp with carries
     before = Block()
     after = Block()
-    before_arg = BlockArg(100, Int)
-    after_blk_arg = BlockArg(101, Int)
+    before_arg = BlockArgument(100, Int)
+    after_blk_arg = BlockArgument(101, Int)
     push!(before.args, before_arg)
     push!(after.args, after_blk_arg)
     before.terminator = ConditionOp(SSAValue(1), [before_arg])
@@ -861,7 +861,7 @@ end
     else_blk.terminator = ContinueOp([SSAValue(88)])   # 1 user carry
 
     body = Block()
-    push!(body.args, BlockArg(1, Int))  # 1 user block arg
+    push!(body.args, BlockArgument(1, Int))  # 1 user block arg
     ifop = IfOp(SSAValue(50), then_blk, else_blk)
     push!(body.body, (10, ifop, Nothing))
     body.terminator = nothing
@@ -933,8 +933,8 @@ end  # loop carries
     @test resolve_call(42) === nothing
     @test resolve_call(Expr(:new, :Foo)) === nothing
 
-    # Inst overload
-    inst = Inst(1, expr_call, Int)
+    # Instruction overload
+    inst = Instruction(1, expr_call, Int)
     result3 = resolve_call(inst)
     @test result3 !== nothing
     @test first(result3) === Base.:+
@@ -958,8 +958,8 @@ end
     @test !iscall(42)
     @test !iscall(Expr(:new, :Foo))
 
-    # Inst overloads
-    inst = Inst(1, expr_call, Int)
+    # Instruction overloads
+    inst = Instruction(1, expr_call, Int)
     @test iscall(inst)
     @test callee(inst) == GlobalRef(Base, :+)
     @test length(callargs(inst)) == 2
@@ -972,3 +972,95 @@ end
 end
 
 end  # expression inspection
+
+@testset "value_type(block, val)" begin
+
+@testset "SSAValue in same block" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    inst = first(instructions(sci.entry))
+    typ = value_type(sci.entry, SSAValue(inst))
+    @test typ !== nothing
+    @test typ == value_type(inst)
+end
+
+@testset "SSAValue from parent block" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x > 0 ? x + 1 : x - 1
+    end |> only
+
+    # Find an SSAValue defined in the entry block and look it up from a nested block
+    for inst in instructions(sci.entry)
+        if stmt(inst) isa IfOp
+            ifop = stmt(inst)
+            then_blk = ifop.then_region
+            # The condition SSAValue is defined in the entry block
+            cond = ifop.condition
+            if cond isa SSAValue
+                typ = value_type(then_blk, cond)
+                @test typ !== nothing
+            end
+            break
+        end
+    end
+end
+
+@testset "BlockArgument" begin
+    sci, _ = code_structured(Tuple{Int}) do n::Int
+        i = 0
+        acc = 0
+        while i < n
+            acc += i
+            i += 1
+        end
+        return acc
+    end |> only
+
+    found = false
+    for inst in instructions(sci.entry)
+        op = stmt(inst)
+        op isa IRStructurizer.ControlFlowOp || continue
+        for blk in blocks(op)
+            if !isempty(arguments(blk))
+                arg = first(arguments(blk))
+                @test value_type(blk, arg) == arg.type
+                found = true
+                break
+            end
+        end
+        found && break
+    end
+    @test found
+end
+
+@testset "Argument" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    # Argument(1) is the function itself, Argument(2) is x::Int
+    typ = value_type(sci.entry, Core.Argument(2))
+    @test typ !== nothing
+end
+
+@testset "constant" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    @test value_type(sci.entry, 42) == Int
+    @test value_type(sci.entry, 3.14) == Float64
+    @test value_type(sci.entry, true) == Bool
+end
+
+@testset "unknown SSAValue" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    @test value_type(sci.entry, SSAValue(999999)) === nothing
+end
+
+end  # value_type(block, val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Core: SSAValue, ReturnNode
 using IRStructurizer: Block, ControlFlowOp, IfOp, ForOp, WhileOp, LoopOp,
                       YieldOp, ContinueOp, BreakOp, ConditionOp,
                       validate_scf, validate_terminators, validate_ssa_defs,
-                      statements, BlockArg
+                      statements, BlockArgument
 using Base: code_ircode
 
 # Used by "step defined inside loop body" test — must be module-level const

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -545,9 +545,9 @@ end
     @test before.terminator isa ConditionOp
     cond_op = before.terminator
 
-    # The result should be BlockArg, not SSAValue
+    # The result should be BlockArgument, not SSAValue
     @test !isempty(cond_op.args)
-    @test cond_op.args[1] isa IRStructurizer.BlockArg
+    @test cond_op.args[1] isa IRStructurizer.BlockArgument
 end
 
 @testset "SESE while-loop becomes ForOp, non-SESE stays LoopOp" begin


### PR DESCRIPTION
Also clarify that SSAValue/Argument/BlockArgument are structural, Instruction is a helper.

Not entirely happy with the design yet, but this package isn't widely depended on anyway so let's go with small incremental steps.