### PR TITLE
Add operands(), def()/defs(), and block field on Instruction.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ Get or set the block's terminator (`ReturnNode`, `YieldOp`, `ContinueOp`, `Break
 
 Get the carried-value operands of a terminator. Provides uniform access regardless of terminator type (`.values` for `YieldOp`/`ContinueOp`/`BreakOp`, `.args` for `ConditionOp`).
 
+#### `operands(op::ControlFlowOp)` → `Vector{IRValue}`
+
+Get the values flowing into a control flow operation from the parent scope:
+
+- `IfOp` → `[condition]`
+- `ForOp` → `[lower, upper, step, init_values...]`
+- `WhileOp` → `copy(init_values)`
+- `LoopOp` → `copy(init_values)`
+
+#### `operands(block, inst)` → `Vector{Any}`
+
+Extract all value operands from an instruction's statement (Expr args).
+
 #### `arguments(block::Block)` → `Vector{BlockArg}`
 
 Get the block arguments (loop-carried values, induction variables).
@@ -114,6 +127,25 @@ Get the raw function reference from a call expression without resolving `GlobalR
 #### `callargs(stmt_or_inst)` → `SubArray`
 
 Get the operand arguments of a call expression (excludes the function reference).
+
+### Definition Lookup
+
+#### `def(root, val::SSAValue)` → `Instruction` or `nothing`
+
+Find the instruction that defines an SSA value. The instruction's `block` field gives the containing block. Performs a linear scan — for repeated queries, use `defs(root)`.
+
+#### `defs(root)` / `def(idx, val::SSAValue)`
+
+Pre-built index for O(1) definition lookup. Analogous to `uses(block)` which returns a `UseIndex`.
+
+```julia
+idx = defs(sci)
+inst = def(idx, SSAValue(3))
+if inst !== nothing
+    stmt(inst)        # the statement
+    block(inst)       # the containing block
+end
+```
 
 ### Block Mutation
 

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -1,6 +1,6 @@
 # structured IR definitions
 
-export StructuredIRCode, Undef, Instruction, instructions, arguments, value_type, stmt,
+export StructuredIRCode, Undef, Instruction, instructions, arguments, value_type, stmt, block,
        insert_before!, insert_after!, terminator, terminator!, operands
 
 #=============================================================================
@@ -56,18 +56,17 @@ const IRValue = Any
 """
     Instruction
 
-A convenience view over an SSAMap entry, bundling an SSA index with its statement
-and type. Yielded by `instructions(block)` and usable as a key in `UseIndex`.
+A view over an SSAMap entry, bundling an SSA index with its statement, type,
+and containing block. Yielded by `instructions(block)` and usable as a key
+in `UseIndex`.
 
-Unlike the structural IR elements (`SSAValue`, `BlockArgument`, `Argument`) which appear
-as operands in the IR, an `Instruction` is constructed on-the-fly during iteration
-and provides convenient access to all three aspects of a definition: its identity
-(`ssa_idx`), its statement (`stmt`), and its Julia type (`typ`).
+Analogous to MLIR's `Operation` which knows its parent `Block` via `getBlock()`.
 """
 struct Instruction
     ssa_idx::Int
     stmt::Any
     typ::Any
+    block::Any  # ::Block — untyped to avoid forward reference
 end
 
 """Get the Julia type of the instruction result."""
@@ -75,6 +74,9 @@ value_type(i::Instruction) = i.typ
 
 """Get the underlying statement (Expr, ControlFlowOp, etc.)."""
 stmt(i::Instruction) = i.stmt
+
+"""Get the block containing this instruction."""
+block(i::Instruction) = i.block
 
 """Convert to SSAValue for use in operand positions."""
 Core.SSAValue(i::Instruction) = SSAValue(i.ssa_idx)
@@ -239,6 +241,8 @@ operands(t::ConditionOp) = t.args
  Abstract Control Flow Type
 =============================================================================#
 
+# operands() for ControlFlowOps — defined after the types (below)
+
 """
     ControlFlowOp
 
@@ -310,19 +314,19 @@ need to interact with SSAMap directly.
 
 Analogous to LLVM.jl's `instructions(bb::BasicBlock)`.
 """
-instructions(block::Block) = InstructionIterator(block.body)
+instructions(b::Block) = InstructionIterator(b)
 
 struct InstructionIterator
-    body::SSAMap
+    block::Block
 end
 
-Base.length(it::InstructionIterator) = length(it.body)
+Base.length(it::InstructionIterator) = length(it.block.body)
 Base.eltype(::Type{InstructionIterator}) = Instruction
 
 function Base.iterate(it::InstructionIterator, state::Int=1)
-    m = it.body
+    m = it.block.body
     state > length(m.ssa_idxes) && return nothing
-    inst = Instruction(m.ssa_idxes[state], m.stmts[state], m.types[state])
+    inst = Instruction(m.ssa_idxes[state], m.stmts[state], m.types[state], it.block)
     return inst, state + 1
 end
 
@@ -470,6 +474,17 @@ blocks(op::ForOp) = (op.body,)
 blocks(op::WhileOp) = (op.before, op.after)
 blocks(op::LoopOp) = (op.body,)
 blocks(::ControlFlowOp) = ()
+
+"""
+    operands(op::ControlFlowOp) -> Vector{IRValue}
+
+Get the values flowing into a control flow operation from the parent scope.
+For loops, this includes bounds and init values. For IfOp, this is the condition.
+"""
+operands(op::IfOp)    = Any[op.condition]
+operands(op::ForOp)   = Any[op.lower, op.upper, op.step, op.init_values...]
+operands(op::WhileOp) = copy(op.init_values)
+operands(op::LoopOp)  = copy(op.init_values)
 
 #=============================================================================
  StructuredIRCode - the structured IR for a function

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -16,7 +16,8 @@ public root, parent, walk_uses!, IndexedUseRef
 export insert_before!, insert_after!, eachblock, findblock,
        update_type!, new_block_arg!,
        resolve_call, iscall, callee, callargs,
-       reachable_terminators, walk, after_arg
+       reachable_terminators, walk, after_arg,
+       def, defs
 
 """
     parent(block::Block) -> Union{Block, StructuredIRCode}
@@ -60,7 +61,7 @@ function Base.push!(block::Block, @nospecialize(stmt), @nospecialize(typ))
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ)
+    return Instruction(idx, stmt, typ, block)
 end
 
 """
@@ -80,7 +81,7 @@ function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(typ))
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ)
+    return Instruction(idx, stmt, typ, block)
 end
 
 """
@@ -159,7 +160,7 @@ function insert_before!(block::Block, ref::Instruction, @nospecialize(stmt), @no
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     insert_before_idx!(block.body, ref.ssa_idx, idx, stmt, typ)
-    return Instruction(idx, stmt, typ)
+    return Instruction(idx, stmt, typ, block)
 end
 
 function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, typ)
@@ -180,7 +181,7 @@ function insert_after!(block::Block, ref::Instruction, @nospecialize(stmt), @nos
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     insert_after_idx!(block.body, ref.ssa_idx, idx, stmt, typ)
-    return Instruction(idx, stmt, typ)
+    return Instruction(idx, stmt, typ, block)
 end
 
 function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, typ)
@@ -206,7 +207,7 @@ function insert_before!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospe
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ)
+    return Instruction(idx, stmt, typ, block)
 end
 
 """
@@ -224,7 +225,7 @@ function insert_after!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospec
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ)
+    return Instruction(idx, stmt, typ, block)
 end
 
 
@@ -1012,3 +1013,99 @@ end
 Convenience overload: extracts call arguments from the underlying statement.
 """
 callargs(inst::Instruction) = callargs(inst.stmt::Expr)
+
+
+#=============================================================================
+ Instruction operands
+=============================================================================#
+
+"""
+    operands(block::Block, inst::Instruction) -> Vector{Any}
+
+Extract data operands from an instruction's statement — the values the
+instruction consumes. Excludes the callee and type refs (use `callee()`
+or `callargs()` for call-specific access). Extensible via dispatch on
+the statement type for domain-specific IR nodes.
+"""
+operands(block::Block, inst::Instruction) = operands(block, inst.stmt)
+
+function operands(block::Block, @nospecialize(s))
+    s isa Expr || return Any[]
+    if s.head === :call
+        # args = [callee, arg1, arg2, ...] — skip callee
+        return collect(Any, @view s.args[2:end])
+    elseif s.head === :invoke
+        # args = [CodeInstance, callee, arg1, arg2, ...] — skip CI and callee
+        return collect(Any, @view s.args[3:end])
+    elseif s.head === :new
+        # args = [Type, field1, field2, ...] — skip type
+        return collect(Any, @view s.args[2:end])
+    elseif s.head === :splatnew
+        # args = [Type, tuple] — skip type
+        return collect(Any, @view s.args[2:end])
+    else
+        return collect(Any, s.args)
+    end
+end
+
+
+#=============================================================================
+ Definition lookup
+=============================================================================#
+
+"""
+    def(root, val::Core.SSAValue) -> Union{Instruction, Nothing}
+
+Find the instruction that defines `val`. Performs a linear scan over
+all blocks. The instruction's `block` field gives the containing block.
+For repeated queries, build an index via [`defs`](@ref) instead.
+"""
+function def(root::Union{Block, StructuredIRCode}, val::Core.SSAValue)
+    blk = root isa StructuredIRCode ? root.entry : root
+    target = val.id
+    for b in eachblock(blk)
+        for inst in instructions(b)
+            inst.ssa_idx == target && return inst
+        end
+    end
+    return nothing
+end
+
+"""
+    DefIndex
+
+Pre-built index mapping SSA indices to their defining `Instruction`.
+Build via `defs(root)`, query via `def(idx, val)`.
+Analogous to `UseIndex` / `uses(block)`.
+"""
+struct DefIndex
+    map::Dict{Int, Instruction}
+end
+
+"""
+    defs(root) -> DefIndex
+
+Build a definition index for all instructions in `root` (recursively).
+Returns a `DefIndex` that supports O(1) lookup via `def(idx, val)`.
+
+Analogous to `uses(block)` which returns a `UseIndex`.
+"""
+function defs(root::Union{Block, StructuredIRCode})
+    blk = root isa StructuredIRCode ? root.entry : root
+    map = Dict{Int, Instruction}()
+    for b in eachblock(blk)
+        for inst in instructions(b)
+            map[inst.ssa_idx] = inst
+        end
+    end
+    return DefIndex(map)
+end
+
+"""
+    def(idx::DefIndex, val::Core.SSAValue) -> Union{Instruction, Nothing}
+
+O(1) lookup of the instruction defining `val`.
+"""
+def(idx::DefIndex, val::Core.SSAValue) = get(idx.map, val.id, nothing)
+
+Base.haskey(idx::DefIndex, val::Core.SSAValue) = haskey(idx.map, val.id)

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -249,7 +249,7 @@ end
         x + 1
     end |> only
 
-    bad_ref = Instruction(999999, nothing, Nothing)
+    bad_ref = Instruction(999999, nothing, Nothing, Block())
     @test_throws KeyError insert_before!(sci.entry, bad_ref, Expr(:call, :x), Int)
 end
 
@@ -305,7 +305,7 @@ end
     @test found === sci.entry
 
     # Non-existent instruction returns nothing
-    @test findblock(sci, Instruction(999999, nothing, Nothing)) === nothing
+    @test findblock(sci, Instruction(999999, nothing, Nothing, Block())) === nothing
 end
 
 @testset "reachable_terminators(block)" begin
@@ -972,7 +972,7 @@ end  # loop carries
     @test resolve_call(block, Expr(:new, :Foo)) === nothing
 
     # Instruction overload
-    inst = Instruction(1, expr_call, Int)
+    inst = Instruction(1, expr_call, Int, Block())
     result3 = resolve_call(block, inst)
     @test result3 !== nothing
     @test first(result3) === Base.:+
@@ -1028,7 +1028,7 @@ end
     @test !iscall(Expr(:new, :Foo))
 
     # Instruction overloads
-    inst = Instruction(1, expr_call, Int)
+    inst = Instruction(1, expr_call, Int, Block())
     @test iscall(inst)
     @test callee(inst) == GlobalRef(Base, :+)
     @test length(callargs(inst)) == 2
@@ -1133,3 +1133,195 @@ end
 end
 
 end  # value_type(block, val)
+
+@testset "operands(op::ControlFlowOp)" begin
+
+@testset "IfOp" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x > 0 ? x + 1 : x - 1
+    end |> only
+
+    for inst in instructions(sci.entry)
+        if stmt(inst) isa IfOp
+            ops = operands(stmt(inst))
+            @test length(ops) == 1
+            @test ops[1] isa SSAValue  # the condition
+            break
+        end
+    end
+end
+
+@testset "ForOp" begin
+    sci, _ = code_structured(Tuple{Int}) do n::Int
+        s = 0
+        i = 1
+        while i <= n
+            s += i
+            i += 1
+        end
+        s
+    end |> only
+
+    found = false
+    walk(sci) do inst, block
+        if stmt(inst) isa ForOp
+            op = stmt(inst)
+            ops = operands(op)
+            # lower, upper, step, plus any init_values
+            @test length(ops) >= 3
+            found = true
+        end
+        :advance
+    end
+    @test found
+end
+
+@testset "WhileOp" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        while x > 0
+            x -= 1
+        end
+        x
+    end |> only
+
+    found = false
+    walk(sci) do inst, block
+        if stmt(inst) isa WhileOp
+            op = stmt(inst)
+            ops = operands(op)
+            # init_values only (WhileOp has no explicit bounds)
+            @test ops isa Vector
+            @test length(ops) == length(op.init_values)
+            # operands returns a copy, not a reference
+            @test ops !== op.init_values
+            found = true
+        end
+        :advance
+    end
+    @test found
+end
+
+@testset "LoopOp" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        while true
+            x -= 1
+            x <= 0 && break
+        end
+        x
+    end |> only
+
+    found = false
+    walk(sci) do inst, block
+        if stmt(inst) isa LoopOp
+            op = stmt(inst)
+            ops = operands(op)
+            @test ops isa Vector
+            @test length(ops) == length(op.init_values)
+            found = true
+        end
+        :advance
+    end
+    @test found
+end
+
+end  # operands(op::ControlFlowOp)
+
+@testset "operands(block, inst)" begin
+
+@testset "call expression" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    # Find a call instruction (first instruction may not be an Expr on all Julia versions)
+    found = false
+    for inst in instructions(sci.entry)
+        if iscall(inst)
+            ops = operands(sci.entry, inst)
+            @test ops isa Vector
+            @test !isempty(ops)
+            found = true
+            break
+        end
+    end
+    @test found
+end
+
+@testset "non-call statement" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    # Insert a non-Expr statement to test operands returns empty
+    inst = push!(sci.entry, 42, Int)
+    ops = operands(sci.entry, inst)
+    @test isempty(ops)
+end
+
+end  # operands(block, inst)
+
+@testset "def" begin
+
+@testset "basic lookup" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    # First instruction defines some SSAValue
+    inst1 = first(instructions(sci.entry))
+    result = def(sci, SSAValue(inst1.ssa_idx))
+    @test result !== nothing
+    @test result.ssa_idx == inst1.ssa_idx
+    @test block(result) === sci.entry
+end
+
+@testset "nested block" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x > 0 ? x + 1 : x - 1
+    end |> only
+
+    # Find an SSAValue defined inside a nested block (then/else region)
+    for inst in instructions(sci.entry)
+        if stmt(inst) isa IfOp
+            op = stmt(inst)
+            inner_inst = first(instructions(op.then_region))
+            result = def(sci, SSAValue(inner_inst.ssa_idx))
+            @test result !== nothing
+            @test result.ssa_idx == inner_inst.ssa_idx
+            @test block(result) === op.then_region
+            break
+        end
+    end
+end
+
+@testset "not found" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    @test def(sci, SSAValue(999999)) === nothing
+end
+
+@testset "defs" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x > 0 ? x + 1 : x - 1
+    end |> only
+
+    idx = defs(sci)
+
+    # All instructions are in the index
+    count = 0
+    walk(sci) do inst, blk
+        result = def(idx, SSAValue(inst.ssa_idx))
+        @test result !== nothing
+        @test result.ssa_idx == inst.ssa_idx
+        count += 1
+        :advance
+    end
+    @test count == length(idx.map)
+
+    # Missing SSAValue
+    @test def(idx, SSAValue(999999)) === nothing
+end
+
+end  # def


### PR DESCRIPTION
New utilities preparing for cuTile pass migration:

- operands(op::ControlFlowOp): uniform operand access for CF ops (IfOp, ForOp, WhileOp, LoopOp)
- operands(block, inst): data operands for instructions (excludes callee/type refs), extensible via dispatch for domain-specific IR nodes
- def(root, val): find the Instruction defining an SSAValue
- defs(root): pre-built DefIndex for O(1) lookups, paralleling uses()/UseIndex
- Instruction now carries a block field (like MLIR's Operation::getBlock()), so def() returns Instruction? directly