### PR TITLE
Add code motion primitives and extensible operands.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Get the values flowing into a control flow operation from the parent scope:
 
 #### `operands(block, inst)` → `Vector{Any}`
 
-Extract all value operands from an instruction's statement (Expr args).
+Extract data operands from an instruction's statement. Handles `Expr` (`:call`/`:invoke`/`:new`/`:splatnew`), `PiNode`, and `ControlFlowOp`. Returns `Any[]` for unknown types. Extensible via `operands(::Block, s::MyType)` for domain-specific IR nodes.
 
 #### `arguments(block::Block)` → `Vector{BlockArg}`
 
@@ -159,6 +159,10 @@ Append or prepend an instruction.
 
 Insert relative to an existing `Inst` or `SSAValue`.
 
+#### `move_before!(inst, target)` / `move_after!(inst, target)`
+
+Move an instruction from its current block to before/after `target` in `target`'s block. The instruction retains its SSA index. Analogous to MLIR's `Operation::moveBefore`/`moveAfter`.
+
 #### `delete!(block, inst::Inst)`
 
 Remove an instruction from a block.
@@ -170,6 +174,10 @@ Remove all instructions from the block body, preserving args, terminator, and pa
 #### `val in block` / `val ∈ block` → `Bool`
 
 Check if a value is defined in this block. Returns `true` for `SSAValue`s in the body and `BlockArgument`s in the args; `false` for everything else (constants, `Argument`s, etc.).
+
+#### `is_defined_outside(val, block_or_loop_op)` → `Bool`
+
+Check whether a value is defined outside a block (and all its descendants), or outside a loop operation's regions. The loop-op overloads handle values like `ForOp.iv_arg` that aren't in the body's block args. Analogous to MLIR's `LoopLikeOpInterface::isDefinedOutsideOfLoop`.
 
 #### `update_type!(block, inst, new_type)`
 

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -6,6 +6,8 @@
 # Use tracking: uses(), replace_uses!
 # Loop carries: carries()
 # Expression inspection: resolve_call, iscall, callee, callargs
+# Scope queries: is_defined_outside
+# Instruction movement: move_before!, move_after!
 
 
 #=============================================================================
@@ -17,7 +19,8 @@ export insert_before!, insert_after!, eachblock, findblock,
        update_type!, new_block_arg!,
        resolve_call, iscall, callee, callargs,
        reachable_terminators, walk, after_arg,
-       def, defs
+       def, defs,
+       is_defined_outside, move_before!, move_after!
 
 """
     parent(block::Block) -> Union{Block, StructuredIRCode}
@@ -974,32 +977,30 @@ callargs(inst::Instruction) = callargs(inst.stmt::Expr)
 
 """
     operands(block::Block, inst::Instruction) -> Vector{Any}
+    operands(block::Block, stmt) -> Vector{Any}
 
 Extract data operands from an instruction's statement — the values the
-instruction consumes. Excludes the callee and type refs (use `callee()`
-or `callargs()` for call-specific access). Extensible via dispatch on
-the statement type for domain-specific IR nodes.
+instruction consumes. Handles `PiNode` and `ControlFlowOp` types natively.
+Returns `Any[]` for unknown statement types.
+
+Extend via `operands(::Block, s::MyType)` for domain-specific IR nodes.
 """
 operands(block::Block, inst::Instruction) = operands(block, inst.stmt)
 
-function operands(block::Block, @nospecialize(s))
-    s isa Expr || return Any[]
+operands(::Block, s::PiNode) = Any[s.val]
+operands(::Block, s::ControlFlowOp) = operands(s)
+function operands(::Block, s::Expr)
     if s.head === :call
-        # args = [callee, arg1, arg2, ...] — skip callee
-        return collect(Any, @view s.args[2:end])
+        return @view s.args[2:end]
     elseif s.head === :invoke
-        # args = [CodeInstance, callee, arg1, arg2, ...] — skip CI and callee
-        return collect(Any, @view s.args[3:end])
-    elseif s.head === :new
-        # args = [Type, field1, field2, ...] — skip type
-        return collect(Any, @view s.args[2:end])
-    elseif s.head === :splatnew
-        # args = [Type, tuple] — skip type
-        return collect(Any, @view s.args[2:end])
+        return @view s.args[3:end]
+    elseif s.head === :new || s.head === :splatnew
+        return @view s.args[2:end]
     else
-        return collect(Any, s.args)
+        return s.args
     end
 end
+operands(::Block, @nospecialize(_)) = Any[]
 
 
 #=============================================================================
@@ -1062,3 +1063,115 @@ O(1) lookup of the instruction defining `val`.
 def(idx::DefIndex, val::Core.SSAValue) = get(idx.map, val.id, nothing)
 
 Base.haskey(idx::DefIndex, val::Core.SSAValue) = haskey(idx.map, val.id)
+
+
+#=============================================================================
+ Scope queries
+=============================================================================#
+
+"""
+    is_defined_outside(val, block::Block) -> Bool
+    is_defined_outside(val, op::ForOp) -> Bool
+    is_defined_outside(val, op::WhileOp) -> Bool
+    is_defined_outside(val, op::LoopOp) -> Bool
+
+Check whether `val` is defined outside a block (and all its descendants),
+or outside a loop operation's regions.
+
+The loop-op overloads handle values that are conceptually "inside" the loop
+but not stored in a block's args — e.g., `ForOp.iv_arg`.
+
+`Argument`s (function parameters), constants, `GlobalRef`s, and other
+non-SSA values are always considered outside.
+
+Analogous to MLIR's `LoopLikeOpInterface::isDefinedOutsideOfLoop`.
+"""
+function is_defined_outside(@nospecialize(val), block::Block)
+    if val isa SSAValue
+        for b in eachblock(block)
+            val ∈ b && return false
+        end
+        return true
+    elseif val isa BlockArgument
+        for b in eachblock(block)
+            val ∈ b && return false
+        end
+        return true
+    else
+        return true
+    end
+end
+
+function is_defined_outside(@nospecialize(val), op::ForOp)
+    val === op.iv_arg && return false
+    return is_defined_outside(val, op.body)
+end
+
+function is_defined_outside(@nospecialize(val), op::WhileOp)
+    return is_defined_outside(val, op.before) && is_defined_outside(val, op.after)
+end
+
+function is_defined_outside(@nospecialize(val), op::LoopOp)
+    return is_defined_outside(val, op.body)
+end
+
+
+#=============================================================================
+ Instruction movement
+=============================================================================#
+
+"""
+    move_before!(inst::Instruction, target::Instruction)
+
+Move `inst` from its current block to just before `target` in `target`'s block.
+The instruction retains its SSA index. Sub-block parents are updated if the
+instruction is a `ControlFlowOp`.
+
+Analogous to MLIR's `Operation::moveBefore`.
+"""
+function move_before!(inst::Instruction, target::Instruction)
+    src = inst.block::Block
+    dst = target.block::Block
+
+    # Remove from source
+    delete!(src.body, inst.ssa_idx)
+
+    # Insert before target in destination
+    insert_before_idx!(dst.body, target.ssa_idx, inst.ssa_idx, inst.stmt, inst.typ)
+
+    # Update sub-block parents
+    if inst.stmt isa ControlFlowOp
+        for b in blocks(inst.stmt)
+            b.parent = dst
+        end
+    end
+    return inst
+end
+
+"""
+    move_after!(inst::Instruction, target::Instruction)
+
+Move `inst` from its current block to just after `target` in `target`'s block.
+The instruction retains its SSA index. Sub-block parents are updated if the
+instruction is a `ControlFlowOp`.
+
+Analogous to MLIR's `Operation::moveAfter`.
+"""
+function move_after!(inst::Instruction, target::Instruction)
+    src = inst.block::Block
+    dst = target.block::Block
+
+    # Remove from source
+    delete!(src.body, inst.ssa_idx)
+
+    # Insert after target in destination
+    insert_after_idx!(dst.body, target.ssa_idx, inst.ssa_idx, inst.stmt, inst.typ)
+
+    # Update sub-block parents
+    if inst.stmt isa ControlFlowOp
+        for b in blocks(inst.stmt)
+            b.parent = dst
+        end
+    end
+    return inst
+end

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1290,12 +1290,10 @@ end  # operands(op::ControlFlowOp)
         x + 1
     end |> only
 
-    # Find a call instruction (first instruction may not be an Expr on all Julia versions)
     found = false
     for inst in instructions(sci.entry)
         if iscall(inst)
             ops = operands(sci.entry, inst)
-            @test ops isa Vector
             @test !isempty(ops)
             found = true
             break
@@ -1382,3 +1380,138 @@ end
 end
 
 end  # def
+
+@testset "is_defined_outside" begin
+    using IRStructurizer: is_defined_outside, eachblock
+
+    # Simple loop: for i in 1:n; acc += i; end
+    sci, _ = code_structured(Tuple{Int}) do n::Int
+        acc = 0
+        for i in 1:n
+            acc += i
+        end
+        return acc
+    end |> only
+
+    # Find the ForOp (may be nested inside IfOps from bounds checking)
+    for_op = nothing
+    for b in eachblock(sci.entry)
+        for inst in instructions(b)
+            if stmt(inst) isa ForOp
+                for_op = stmt(inst)::ForOp
+                break
+            end
+        end
+        for_op !== nothing && break
+    end
+    @test for_op !== nothing
+
+    # Function argument is defined outside the loop body
+    @test is_defined_outside(Core.Argument(1), for_op.body)
+
+    # The ForOp's IV is not in body.args but the ForOp overload handles it
+    @test is_defined_outside(for_op.iv_arg, for_op.body)  # block check: not in body.args
+    @test !is_defined_outside(for_op.iv_arg, for_op)      # loop-op check: IS the IV
+
+    # Loop body block args (carries) are inside
+    for ba in for_op.body.args
+        @test !is_defined_outside(ba, for_op.body)
+    end
+
+    # SSAValues defined in the entry block are outside the loop body
+    first_inst = first(instructions(sci.entry))
+    @test is_defined_outside(SSAValue(first_inst.ssa_idx), for_op.body)
+
+    # Constants and literals are always outside
+    @test is_defined_outside(42, for_op.body)
+    @test is_defined_outside(GlobalRef(Base, :+), for_op.body)
+end
+
+@testset "move_before! / move_after!" begin
+    # Use a function that generates multiple entry-level instructions
+    sci, _ = code_structured(Tuple{Int, Int}) do x::Int, y::Int
+        a = x + y
+        b = a * 2
+        return b
+    end |> only
+
+    insts = collect(instructions(sci.entry))
+    @test length(insts) >= 2
+
+    # Record initial order
+    initial_ids = [inst.ssa_idx for inst in insts]
+
+    # Move the last instruction before the first
+    last_inst = insts[end]
+    first_inst = insts[1]
+    move_before!(last_inst, first_inst)
+
+    new_ids = [inst.ssa_idx for inst in instructions(sci.entry)]
+    @test new_ids[1] == initial_ids[end]
+    @test new_ids[2:end] == initial_ids[1:end-1]
+
+    # Move it back after the (now) last instruction
+    insts2 = collect(instructions(sci.entry))
+    move_after!(insts2[1], insts2[end])
+
+    restored_ids = [inst.ssa_idx for inst in instructions(sci.entry)]
+    @test restored_ids == initial_ids
+end
+
+@testset "move_before! across blocks" begin
+    # Create a function with an if/else to get multiple blocks
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        if x > 0
+            y = x + 1
+            y + 2
+        else
+            x - 1
+        end
+    end |> only
+
+    # Find the IfOp
+    if_inst = nothing
+    for inst in instructions(sci.entry)
+        if stmt(inst) isa IfOp
+            if_inst = inst
+            break
+        end
+    end
+    @test if_inst !== nothing
+    if_op = stmt(if_inst)::IfOp
+
+    then_block = if_op.then_region
+    then_insts = collect(instructions(then_block))
+    @test length(then_insts) >= 1
+
+    # Move first instruction from then-block to entry (before the IfOp)
+    moved = then_insts[1]
+    moved_id = moved.ssa_idx
+    move_before!(moved, if_inst)
+
+    # Verify it's no longer in then-block
+    then_ids = [i.ssa_idx for i in instructions(then_block)]
+    @test moved_id ∉ then_ids
+
+    # Verify it's now in entry block, before the IfOp
+    entry_ids = [i.ssa_idx for i in instructions(sci.entry)]
+    if_pos = findfirst(==(if_inst.ssa_idx), entry_ids)
+    moved_pos = findfirst(==(moved_id), entry_ids)
+    @test moved_pos !== nothing
+    @test moved_pos < if_pos
+end
+
+@testset "operands dispatches on IR types" begin
+    # PiNode
+    pi = Core.PiNode(SSAValue(1), Int)
+    block = Block()
+    @test operands(block, pi) == Any[SSAValue(1)]
+
+    # ControlFlowOp (IfOp) — delegates to operands(op)
+    if_op = IfOp(SSAValue(5), Block(), Block())
+    @test operands(block, if_op) == Any[SSAValue(5)]
+
+    # Unknown type falls back to empty
+    @test operands(block, 42) == Any[]
+    @test operands(block, GlobalRef(Base, :+)) == Any[]
+end


### PR DESCRIPTION
Code motion:
- `move_before!(inst, target)` / `move_after!(inst, target)`: move an instruction between blocks. Analogous to MLIR's Operation::moveBefore.

Region queries:
- `is_defined_outside(val, block)`: check whether a value is defined outside a block and its descendants. Analogous to MLIR's isDefinedOutsideOfLoop.

Operands:
- `operands(block, stmt)` now dispatches on IR types (PiNode, ControlFlowOp) and returns `Any[]` for unknown types. Consumers extend it for their own statement types.