### PR TITLE
Validation: check IfOp yields against the declared result type.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/ir/validation.jl
+++ b/src/ir/validation.jl
@@ -106,7 +106,7 @@ function validate_terminators!(errors::Vector{String}, sci::StructuredIRCode, bl
     for (idx, entry) in block.body
         stmt = entry.stmt
         if stmt isa IfOp
-            validate_if_terminators!(errors, sci, stmt, idx)
+            validate_if_terminators!(errors, sci, stmt, idx, entry.typ)
         elseif stmt isa ForOp
             validate_for_terminators!(errors, sci, stmt, idx)
         elseif stmt isa WhileOp
@@ -117,7 +117,23 @@ function validate_terminators!(errors::Vector{String}, sci::StructuredIRCode, bl
     end
 end
 
-function validate_if_terminators!(errors::Vector{String}, sci::StructuredIRCode, op::IfOp, idx::Int)
+# Extract the per-position expected types from an IfOp's declared result type.
+# The structurizer emits `Tuple{phi_types...}` (or `Tuple{}` / `Nothing` when
+# there are no yielded values). Returns `nothing` when no per-position bound is
+# available, in which case per-position type checking is skipped.
+function ifop_expected_yield_types(@nospecialize(result_type))
+    result_type isa DataType || return nothing
+    result_type <: Tuple || return nothing
+    # Reject the unparameterized `Tuple` (no per-position info) and vararg
+    # tuples (arity isn't fixed). Concrete abstract-element tuples like
+    # `Tuple{Real}` are fine — their parameters are positionally indexable.
+    result_type === Tuple && return nothing
+    Base.isvatuple(result_type) && return nothing
+    return result_type.parameters
+end
+
+function validate_if_terminators!(errors::Vector{String}, sci::StructuredIRCode,
+                                   op::IfOp, idx::Int, @nospecialize(result_type))
     then_term = op.then_region.terminator
     else_term = op.else_region.terminator
 
@@ -131,7 +147,20 @@ function validate_if_terminators!(errors::Vector{String}, sci::StructuredIRCode,
         push!(errors, "IfOp at %$idx: else region must have explicit terminator, got nothing")
     end
 
-    # Validate yield arity and types: both branches must yield same number of values with matching types
+    # Validate yield arity and types against the IfOp's declared result type.
+    #
+    # Julia's own IR verifier (Compiler/src/ssair/verify.jl) only requires that
+    # each phi edge value's type be a sublattice element of the phi's declared
+    # type — it never compares edge values to each other. Branches may yield
+    # values whose types are disjoint (e.g. `Int` and `String` joining to
+    # `Union{Int,String}`, or `Int` and `Float64` joining to `Real`); what
+    # matters is that each yield conforms to the declared join.
+    #
+    # The structurizer records that join at the IfOp's SSA entry as
+    # `Tuple{phi_types...}` (see `emit_ifop_result!`), so we mirror Julia's
+    # check here: for each position i, both yields must be <: the i-th element
+    # of the declared tuple. `<:` is a conservative approximation of the lattice
+    # `⊑` Julia uses internally; it rejects no IR that `⊑` would accept.
     if then_term isa YieldOp && else_term isa YieldOp
         then_arity = length(then_term.values)
         else_arity = length(else_term.values)
@@ -139,14 +168,17 @@ function validate_if_terminators!(errors::Vector{String}, sci::StructuredIRCode,
             push!(errors, "IfOp at %$idx: yield arity mismatch (then yields $then_arity, else yields $else_arity)")
         end
 
-        # Type validation for matching positions (Undef matches any type)
-        for i in 1:min(then_arity, else_arity)
-            then_term.values[i] isa Undef && continue
-            else_term.values[i] isa Undef && continue
-            then_type = resolve_type(sci, then_term.values[i])
-            else_type = resolve_type(sci, else_term.values[i])
-            if then_type !== nothing && else_type !== nothing && then_type != else_type
-                push!(errors, "IfOp at %$idx: yield type mismatch at position $i (then: $then_type, else: $else_type)")
+        expected = ifop_expected_yield_types(result_type)
+        if expected !== nothing
+            arity = min(then_arity, else_arity)
+            # Flag yield arity not matching the declared result tuple.
+            if then_arity == else_arity && then_arity != length(expected)
+                push!(errors, "IfOp at %$idx: yield arity ($then_arity) does not match declared result type $result_type (expected $(length(expected)))")
+            end
+            for i in 1:min(arity, length(expected))
+                Ti = expected[i]
+                check_yield_type!(errors, sci, then_term.values[i], Ti, idx, i, "then")
+                check_yield_type!(errors, sci, else_term.values[i], Ti, idx, i, "else")
             end
         end
     end
@@ -154,6 +186,21 @@ function validate_if_terminators!(errors::Vector{String}, sci::StructuredIRCode,
     # Recursively validate nested ops
     validate_terminators!(errors, sci, op.then_region)
     validate_terminators!(errors, sci, op.else_region)
+end
+
+# Check a single yield value against the IfOp's declared per-position type.
+# `Undef` placeholders (used for uninitialized slots on one branch) are skipped
+# — their recorded type is already the declared slot type, so the <: check is
+# trivially satisfied, but an explicit skip keeps intent clear.
+function check_yield_type!(errors::Vector{String}, sci::StructuredIRCode,
+                            @nospecialize(value), @nospecialize(expected),
+                            idx::Int, pos::Int, branch::String)
+    value isa Undef && return
+    ty = resolve_type(sci, value)
+    ty === nothing && return
+    if !(ty <: expected)
+        push!(errors, "IfOp at %$idx: $branch yield at position $pos has type $ty, not <: declared $expected")
+    end
 end
 
 function validate_for_terminators!(errors::Vector{String}, sci::StructuredIRCode, op::ForOp, idx::Int)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -64,6 +64,112 @@ end
     end
 end
 
+@testset "validation: IfOp yield types checked against declared result" begin
+    # Mirror Julia's own phi-node verifier: each yield must be <: the IfOp's
+    # declared per-position result type. Yields in the two branches do *not*
+    # need to be related to each other — Julia IR routinely merges disjoint
+    # types at phi nodes (the declared phi type is the join, not either edge).
+
+    # Helper: build a minimal SCI with an IfOp yielding one value per branch.
+    function mk_if_sci(arg_then, arg_else, argtypes, result_type)
+        then_blk = Block(); then_blk.terminator = YieldOp(Any[arg_then])
+        else_blk = Block(); else_blk.terminator = YieldOp(Any[arg_else])
+        entry = Block()
+        push!(entry, 1, IfOp(true, then_blk, else_blk), result_type)
+        push!(entry, 2, Expr(:call, Core.getfield, SSAValue(1), 1), result_type.parameters[1])
+        entry.terminator = Core.ReturnNode(SSAValue(2))
+        return StructuredIRCode(argtypes, Any[], entry, 10)
+    end
+
+    # Case 1: one branch's type subtypes the other (Ptr{Nothing} vs Any,
+    # declared Any). Both yields <: Any → accepted.
+    sci = mk_if_sci(Core.Argument(2), Core.Argument(3),
+                    Any[Any, Ptr{Nothing}, Any], Tuple{Any})
+    validate_terminators(sci)  # should not throw
+
+    # Case 2: disjoint concrete types merging to a Union phi.
+    # The previous heuristic (accept only if one type subtypes the other)
+    # rejected this as a "gross mismatch". It's valid IR:
+    # `Int <: Union{Int,String}` and `String <: Union{Int,String}`.
+    sci = mk_if_sci(Core.Argument(2), Core.Argument(3),
+                    Any[Any, Int, String], Tuple{Union{Int,String}})
+    validate_terminators(sci)  # should not throw
+
+    # Case 3: disjoint concrete types merging to an abstract supertype.
+    # `Int <: Real` and `Float64 <: Real`, but neither subtypes the other.
+    # Previously rejected; valid IR.
+    sci = mk_if_sci(Core.Argument(2), Core.Argument(3),
+                    Any[Any, Int, Float64], Tuple{Real})
+    validate_terminators(sci)  # should not throw
+
+    # Case 3b: abstract-element tuple bounds are really checked, not skipped.
+    # A `String` yield under a declared `Tuple{Real}` must still be rejected.
+    sci = mk_if_sci(Core.Argument(2), Core.Argument(3),
+                    Any[Any, Int, String], Tuple{Real})
+    @test_throws ErrorException validate_terminators(sci)
+    try
+        validate_terminators(sci)
+    catch e
+        @test occursin("not <: declared Real", e.msg)
+    end
+
+    # Case 4: both yields are unrelated concrete types joining to `Any` —
+    # what widened dynamic dispatch produces. Previously rejected as a "gross
+    # mismatch" even though `Int <: Any` and `String <: Any`.
+    sci = mk_if_sci(Core.Argument(2), Core.Argument(3),
+                    Any[Any, Int, String], Tuple{Any})
+    validate_terminators(sci)  # should not throw
+
+    # Case 5: a yield that genuinely violates the declared bound (else branch).
+    sci = mk_if_sci(Core.Argument(2), Core.Argument(3),
+                    Any[Any, Int, String], Tuple{Int})
+    @test_throws ErrorException validate_terminators(sci)
+    try
+        validate_terminators(sci)
+    catch e
+        @test occursin("else yield", e.msg)
+        @test occursin("not <: declared Int", e.msg)
+    end
+
+    # Case 6: the then branch violates the declared bound.
+    sci = mk_if_sci(Core.Argument(2), Core.Argument(3),
+                    Any[Any, String, Int], Tuple{Int})
+    @test_throws ErrorException validate_terminators(sci)
+    try
+        validate_terminators(sci)
+    catch e
+        @test occursin("then yield", e.msg)
+        @test occursin("not <: declared Int", e.msg)
+    end
+
+    # Case 7: yield arity does not match the declared result tuple.
+    then_blk = Block(); then_blk.terminator = YieldOp(Any[Core.Argument(2)])
+    else_blk = Block(); else_blk.terminator = YieldOp(Any[Core.Argument(3)])
+    entry = Block()
+    push!(entry, 1, IfOp(true, then_blk, else_blk), Tuple{Int, Int})
+    entry.terminator = Core.ReturnNode(nothing)
+    sci = StructuredIRCode(Any[Any, Int, Int], Any[], entry, 10)
+    @test_throws ErrorException validate_terminators(sci)
+    try
+        validate_terminators(sci)
+    catch e
+        @test occursin("does not match declared result type", e.msg)
+    end
+
+    # Case 8: Undef placeholders are accepted regardless of the declared type.
+    # They stand for uninitialized slots on one branch and carry the declared
+    # slot type by construction; skipping them keeps the check focused on
+    # genuine values.
+    then_blk = Block(); then_blk.terminator = YieldOp(Any[Undef(Int)])
+    else_blk = Block(); else_blk.terminator = YieldOp(Any[Core.Argument(2)])
+    entry = Block()
+    push!(entry, 1, IfOp(true, then_blk, else_blk), Tuple{Int})
+    push!(entry, 2, Expr(:call, Core.getfield, SSAValue(1), 1), Int)
+    entry.terminator = Core.ReturnNode(SSAValue(2))
+    sci = StructuredIRCode(Any[Any, Int], Any[], entry, 10)
+    validate_terminators(sci)  # should not throw
+end
+
 @testset "validation: scope-aware undefined SSA" begin
     # Manually construct IR where an SSA value defined inside an IfOp branch
     # is referenced in the outer scope — should be caught by scoped validation.


### PR DESCRIPTION
The previous strict equality check rejected Julia IR patterns that are trivially valid — e.g. a `PiNode`-narrowed `Ptr{Nothing}` in one branch and an `Any`-typed dynamic-dispatch result in the other, both feeding a phi declared `Any`. The earlier relaxation (accept if either yield type is `<:` the other) was a heuristic with no principled basis: it still rejected disjoint-but-valid patterns like `Int`/`String` merging to `Union{Int,String}`, or `Int`/`Float64` merging to `Real`, while "gross mismatch" had no actual meaning beyond "not related by `<:`".

Julia's own IR verifier (Compiler/src/ssair/verify.jl) compares each phi edge value's type to the phi's declared type, never to the other edges. Mirror that: the structurizer records the join as `Tuple{phi_types...}` on the IfOp's SSA entry (see `emit_ifop_result!` in `src/structurize/loops.jl`), so thread that through to `validate_if_terminators!` and check each branch independently against the per-position declared type. Also flag yield arity that doesn't match the declared tuple length.