### PR TITLE
Walk uses through alias and PiNode statements.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -302,6 +302,17 @@ function Base.setindex!(r::TerminatorReturnNodeUseRef, @nospecialize(v))
     r.block.terminator = ReturnNode(v)
 end
 
+# UseRef for PiNode as a statement (immutable — replacement reconstructs it).
+struct PiNodeUseRef <: UseRef
+    stmts::Vector{Any}
+    pos::Int
+end
+
+Base.getindex(r::PiNodeUseRef) = (r.stmts[r.pos]::PiNode).val
+function Base.setindex!(r::PiNodeUseRef, @nospecialize(v))
+    r.stmts[r.pos] = PiNode(v, (r.stmts[r.pos]::PiNode).typ)
+end
+
 """
     walk_uses!(f, node)
 
@@ -322,6 +333,13 @@ function walk_uses!(f, block::Block)
             walk_uses!(f, stmt)
         elseif stmt isa ReturnNode
             isdefined(stmt, :val) && f(ReturnNodeUseRef(block.body.stmts, i))
+        elseif stmt isa PiNode
+            # PiNode as a statement wraps a single value with type narrowing.
+            f(PiNodeUseRef(block.body.stmts, i))
+        elseif is_value_like_stmt(stmt)
+            # Alias/forwarding statement: stmt IS a value (SSAValue, BlockArgument,
+            # Argument, SlotNumber). Replacement swaps the stmt slot directly.
+            f(IndexedUseRef(block.body.stmts, i))
         else
             # Dispatch to user-defined methods for Expr, custom node types, etc.
             walk_uses!(f, stmt)
@@ -335,6 +353,10 @@ function walk_uses!(f, block::Block)
         walk_uses!(f, term)
     end
 end
+
+"""A statement whose raw value IS the operand — alias/forwarding form."""
+is_value_like_stmt(@nospecialize(s)) =
+    s isa SSAValue || s isa BlockArgument || s isa Argument || s isa SlotNumber
 
 # Fallback for unknown statement types (no-op)
 walk_uses!(f, ::Any) = nothing
@@ -518,6 +540,11 @@ function _references(@nospecialize(stmt), @nospecialize(target))
     elseif stmt isa ReturnNode
         isdefined(stmt, :val) || return false
         normalize_key(stmt.val) == target && return true
+    elseif stmt isa PiNode
+        normalize_key(stmt.val) == target && return true
+    elseif is_value_like_stmt(stmt)
+        # Alias statement: the stmt itself is the referenced value.
+        normalize_key(stmt) == target && return true
     end
     return false
 end
@@ -989,6 +1016,11 @@ operands(block::Block, inst::Instruction) = operands(block, inst.stmt)
 
 operands(::Block, s::PiNode) = Any[s.val]
 operands(::Block, s::ControlFlowOp) = operands(s)
+# Alias statements (stmt IS a value) forward the value itself as their sole operand.
+operands(::Block, s::SSAValue) = Any[s]
+operands(::Block, s::BlockArgument) = Any[s]
+operands(::Block, s::Argument) = Any[s]
+operands(::Block, s::SlotNumber) = Any[s]
 function operands(::Block, s::Expr)
     if s.head === :call
         return @view s.args[2:end]

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -658,6 +658,48 @@ end
     @test !isempty(idx[Core.Argument(2)])
 end
 
+@testset "alias statements (stmt IS a value)" begin
+    # A forwarding statement like `%N = %M` appears after structurization when a
+    # PhiNode collapses to a single predecessor. replace_uses!/users/operands
+    # must treat the raw-SSA stmt as a use site, or downstream consumers that
+    # later delete the referenced value leave dangling references.
+    block = Block()
+    push!(block.body, (1, Expr(:call, GlobalRef(Base, :+), SSAValue(0), SSAValue(0)), Int))
+    push!(block.body, (2, SSAValue(1), Int))           # %2 = %1 (alias)
+    push!(block.body, (3, SSAValue(1), Int))           # %3 = %1 (alias)
+    block.terminator = ReturnNode(SSAValue(2))
+
+    idx = uses(block)
+    @test length(idx[SSAValue(1)]) == 2                # both alias stmts
+
+    u = users(block, SSAValue(1))
+    @test Set(inst.ssa_idx for inst in u) == Set([2, 3])
+
+    replace_uses!(block, SSAValue(1), SSAValue(42))
+    @test block.body.stmts[2] == SSAValue(42)
+    @test block.body.stmts[3] == SSAValue(42)
+    @test isempty(uses(block, SSAValue(1)))
+end
+
+@testset "PiNode as a statement" begin
+    # PiNode is immutable — replace_uses! must reconstruct to swap the referenced
+    # value while preserving the narrowed type.
+    block = Block()
+    push!(block.body, (1, Expr(:call, GlobalRef(Base, :+), SSAValue(0), SSAValue(0)), Int))
+    push!(block.body, (2, PiNode(SSAValue(1), Int), Int))
+    block.terminator = ReturnNode(SSAValue(2))
+
+    @test length(uses(block, SSAValue(1))) == 1
+    u = users(block, SSAValue(1))
+    @test length(u) == 1 && u[1].ssa_idx == 2
+
+    replace_uses!(block, SSAValue(1), SSAValue(99))
+    pi_stmt = block.body.stmts[2]
+    @test pi_stmt isa PiNode
+    @test pi_stmt.val == SSAValue(99)
+    @test pi_stmt.typ === Int
+end
+
 @testset "walk_uses! extensibility" begin
     using IRStructurizer: walk_uses!, IndexedUseRef
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using FileCheck
 using InteractiveUtils: code_llvm
 
 using IRStructurizer
-using Core: SSAValue, ReturnNode, GotoNode, GotoIfNot, PhiNode
+using Core: SSAValue, ReturnNode, GotoNode, GotoIfNot, PhiNode, PiNode
 
 # Internal types used in tests for type-checking structured IR output
 using IRStructurizer: Block, ControlFlowOp, IfOp, ForOp, WhileOp, LoopOp,


### PR DESCRIPTION
Forwarding statements of the form `%N = %M` appear after structurization when a PhiNode collapses to a single predecessor (a pattern seen when a simpler overlay makes `unitrange_last` yield its `stop` argument directly). The use visitor skipped these because `walk_uses!(f, ::Any)` is a no-op, so `replace_uses!` couldn't rewrite through them and a downstream `erase_op!` on the replaced value left dangling SSA references.

Handle both shapes explicitly in `walk_uses!(f, block)`:
  - `stmt isa PiNode`         → reconstructs the immutable PiNode on set
  - alias-like stmt (SSAValue / BlockArgument / Argument / SlotNumber)
    → IndexedUseRef into `block.body.stmts`

Extend `_references` and `operands(::Block, stmt)` with the corresponding branches so `users(block, val)` and operand iteration stay consistent with the new use-site coverage.