### PR TITLE
Resolve literal callables (e.g. IntrinsicFunction) in resolve_callee.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -921,21 +921,27 @@ resolve_call(block::Block, inst::Instruction) = resolve_call(block, inst.stmt)
     resolve_callee(block::Block, ref) -> resolved_func or nothing
 
 Resolve a callee reference to a concrete function value. Uses `singleton_type`
-on the inferred type (mirroring Julia's compiler) for SSAValue and other refs
-with singleton types. Falls back to evaluating GlobalRef and literal values
-directly — necessary for non-singleton types like `Core.IntrinsicFunction`
-where all intrinsics share one type and `singleton_type` returns `nothing`.
+on the inferred type (mirroring Julia's compiler) for symbolic refs (SSAValue,
+Argument, BlockArgument, SlotNumber). Falls back to evaluating GlobalRef and
+literal values directly — necessary for non-singleton types like
+`Core.IntrinsicFunction` where all intrinsics share one type and
+`singleton_type` returns `nothing`. Julia's inliner sometimes substitutes a
+`GlobalRef(Core.Intrinsics, :sub_float)` callee with the literal
+`IntrinsicFunction` value (e.g. when inlining cross-module wrappers like
+`BFloat16s.:-`), so non-symbolic refs are returned as-is.
 """
 function resolve_callee(block::Block, @nospecialize(ref))
-    T = value_type(block, ref)
-    T === nothing && return nothing
-    resolved = Core.Compiler.singleton_type(T)
-    resolved !== nothing && return resolved
-    # Fallback: evaluate GlobalRef directly (needed for Core.IntrinsicFunction
-    # and other non-singleton types where the value can't be recovered from type alone).
+    if ref isa SSAValue || ref isa Argument || ref isa BlockArgument || ref isa SlotNumber
+        T = value_type(block, ref)
+        T === nothing && return nothing
+        return Core.Compiler.singleton_type(T)
+    end
     # GlobalRefs in optimized IR are guaranteed valid — inference rejects undefined bindings.
     ref isa GlobalRef && return getfield(ref.mod, ref.name)
-    return nothing
+    ref isa QuoteNode && return ref.value
+    # Literal callable embedded directly as args[1] (e.g. an IntrinsicFunction
+    # value substituted by Julia's inliner): the ref *is* the function.
+    return ref
 end
 
 """

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1106,6 +1106,16 @@ end  # loop carries
         @test resolve_callee(block, SSAValue(inst)) === singleton
         break
     end
+
+    # Literal IntrinsicFunction in callee position. Julia's inliner can substitute
+    # `GlobalRef(Core.Intrinsics, :sub_float)` with the bare `IntrinsicFunction`
+    # value (e.g., when inlining cross-module wrappers), so resolve_callee must
+    # accept callable literals — `IntrinsicFunction` is non-singleton (all
+    # intrinsics share the type) and not a `GlobalRef`.
+    expr_intr = Expr(:call, Core.Intrinsics.sub_float, SSAValue(1), SSAValue(2))
+    result_intr = resolve_call(block, expr_intr)
+    @test result_intr !== nothing
+    @test first(result_intr) === Core.Intrinsics.sub_float
 end
 
 @testset "iscall / callee / callargs" begin


### PR DESCRIPTION
Julia's inliner sometimes substitutes a GlobalRef callee with the bare function value — e.g. when inlining `BFloat16s.:-(x, y) = Base.sub_float(x, y)`, args[1] becomes the literal `Core.Intrinsics.sub_float` rather than a GlobalRef. Since IntrinsicFunction is non-singleton (all intrinsics share one type), singleton_type returned nothing and resolve_callee bailed, even though the docstring promised literal-value support. Restrict the type-based path to symbolic refs and treat anything else as the function.