### PR TITLE
Carry per-statement IR_FLAG_* bitmask through the SCI.

### DIFF
--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -67,14 +67,26 @@ struct Instruction
     ssa_idx::Int
     stmt::Any
     typ::Any
+    flag::UInt32  # IR_FLAG_* bitmask from Julia inference; 0 (IR_FLAG_NULL) if synthesized
     block::Any  # ::Block — untyped to avoid forward reference
 end
+
+# Convenience: construct without an explicit flag (defaults to IR_FLAG_NULL).
+# Matches the pre-`flag` constructor signature for callers that don't yet
+# carry per-stmt flags through.
+Instruction(ssa_idx::Int, @nospecialize(stmt), @nospecialize(typ), @nospecialize(block)) =
+    Instruction(ssa_idx, stmt, typ, UInt32(0), block)
 
 """Get the Julia type of the instruction result."""
 value_type(i::Instruction) = i.typ
 
 """Get the underlying statement (Expr, ControlFlowOp, etc.)."""
 stmt(i::Instruction) = i.stmt
+
+"""Get the per-statement IR flag bitmask (e.g. `IR_FLAG_EFFECT_FREE`).
+Carried through from `IRCode.stmts.flag` at structurization; 0 for stmts
+synthesized by the structurizer or by downstream passes."""
+flag(i::Instruction) = i.flag
 
 """Get the block containing this instruction."""
 block(i::Instruction) = i.block
@@ -100,31 +112,36 @@ end
 =============================================================================#
 
 """
-    SSAMap <: AbstractDict{Int, NamedTuple{(:stmt, :typ)}}
+    SSAMap <: AbstractDict{Int, NamedTuple{(:stmt, :typ, :flag)}}
 
-An ordered map from SSA indices to `(; stmt, typ)` entries.
+An ordered map from SSA indices to `(; stmt, typ, flag)` entries.
 Used to store block body contents with their original Julia SSA indices.
 
-Indexing by SSA index: `m[ssa_idx]` returns `(; stmt, typ)` or throws `KeyError`,
+`flag` is the per-statement `IR_FLAG_*` bitmask carried over from
+`IRCode.stmts.flag` at structurization (see `Compiler/src/optimize.jl`),
+or `0` (`IR_FLAG_NULL`) for statements synthesized after structurization.
+
+Indexing by SSA index: `m[ssa_idx]` returns `(; stmt, typ, flag)` or throws `KeyError`,
 `get(m, ssa_idx, default)` returns `default` if missing.
-Iteration yields `idx => (; stmt, typ)` pairs, enabling `filter(p -> p.second.stmt isa Foo, m)`.
+Iteration yields `idx => (; stmt, typ, flag)` pairs.
 
 Note: Currently uses linear scan for lookup. If this becomes a bottleneck,
 consider switching to `OrderedDict{Int, NamedTuple}` for O(1) access.
 """
-struct SSAMap <: AbstractDict{Int, @NamedTuple{stmt::Any, typ::Any}}
+struct SSAMap <: AbstractDict{Int, @NamedTuple{stmt::Any, typ::Any, flag::UInt32}}
     ssa_idxes::Vector{Int}
     stmts::Vector{Any}
     types::Vector{Any}
+    flags::Vector{UInt32}  # IR_FLAG_* bitmask per stmt; parallel to stmts/types
 end
 
-SSAMap() = SSAMap(Int[], Any[], Any[])
+SSAMap() = SSAMap(Int[], Any[], Any[], UInt32[])
 
-# Iteration yields idx => (; stmt, typ) pairs
+# Iteration yields idx => (; stmt, typ, flag) pairs
 function Base.iterate(m::SSAMap, state::Int=1)
     state > length(m.ssa_idxes) && return nothing
     idx = m.ssa_idxes[state]
-    entry = (; stmt=m.stmts[state], typ=m.types[state])
+    entry = (; stmt=m.stmts[state], typ=m.types[state], flag=m.flags[state])
     return Pair(idx, entry), state + 1
 end
 
@@ -135,20 +152,29 @@ Base.haskey(m::SSAMap, ssa_idx::Int) = findfirst(==(ssa_idx), m.ssa_idxes) !== n
 function Base.getindex(m::SSAMap, ssa_idx::Int)
     i = findfirst(==(ssa_idx), m.ssa_idxes)
     i === nothing && throw(KeyError(ssa_idx))
-    return (; stmt=m.stmts[i], typ=m.types[i])
+    return (; stmt=m.stmts[i], typ=m.types[i], flag=m.flags[i])
 end
 
 function Base.get(m::SSAMap, ssa_idx::Int, default)
     i = findfirst(==(ssa_idx), m.ssa_idxes)
     i === nothing && return default
-    return (; stmt=m.stmts[i], typ=m.types[i])
+    return (; stmt=m.stmts[i], typ=m.types[i], flag=m.flags[i])
 end
 
-# Push raw tuple
+# Push raw tuple. The 3-tuple form defaults the flag to IR_FLAG_NULL (0) — used
+# by passes that synthesize new statements without an inferred flag of origin.
+# The 4-tuple form takes an explicit flag and is used by the IRCode ingestion
+# site (and by structurizer-internal sites that *relocate* an existing stmt and
+# want to preserve its flag).
 function Base.push!(m::SSAMap, (idx, stmt, typ)::Tuple{Int,Any,Any})
+    push!(m, (idx, stmt, typ, UInt32(0)))
+end
+
+function Base.push!(m::SSAMap, (idx, stmt, typ, flag)::Tuple{Int,Any,Any,UInt32})
     push!(m.ssa_idxes, idx)
     push!(m.stmts, stmt)
     push!(m.types, typ)
+    push!(m.flags, flag)
     return nothing
 end
 
@@ -156,13 +182,24 @@ end
 indices(m::SSAMap) = (idx for idx in m.ssa_idxes)
 statements(m::SSAMap) = (stmt for stmt in m.stmts)
 types(m::SSAMap) = (typ for typ in m.types)
+flags(m::SSAMap) = (f for f in m.flags)
 
-# Mutation: setindex! for replacing a statement in-place
+# Mutation: setindex! for replacing a statement in-place. Two-field form
+# preserves the existing flag; three-field form overwrites it.
 function Base.setindex!(m::SSAMap, entry::NamedTuple{(:stmt, :typ)}, ssa_idx::Int)
     i = findfirst(==(ssa_idx), m.ssa_idxes)
     i === nothing && throw(KeyError(ssa_idx))
     m.stmts[i] = entry.stmt
     m.types[i] = entry.typ
+    return entry
+end
+
+function Base.setindex!(m::SSAMap, entry::NamedTuple{(:stmt, :typ, :flag)}, ssa_idx::Int)
+    i = findfirst(==(ssa_idx), m.ssa_idxes)
+    i === nothing && throw(KeyError(ssa_idx))
+    m.stmts[i] = entry.stmt
+    m.types[i] = entry.typ
+    m.flags[i] = entry.flag
     return entry
 end
 
@@ -173,6 +210,7 @@ function Base.delete!(m::SSAMap, ssa_idx::Int)
     deleteat!(m.ssa_idxes, i)
     deleteat!(m.stmts, i)
     deleteat!(m.types, i)
+    deleteat!(m.flags, i)
     return m
 end
 
@@ -282,12 +320,14 @@ function Base.empty!(block::Block)
 end
 
 """
-    push!(block::Block, idx::Int, stmt, typ)
+    push!(block::Block, idx::Int, stmt, typ, [flag])
 
-Push a statement or control flow op to a block with its SSA index and type.
+Push a statement or control flow op to a block with its SSA index, type, and
+optional `IR_FLAG_*` bitmask (defaults to 0 / `IR_FLAG_NULL`).
 """
-function Base.push!(block::Block, idx::Int, @nospecialize(stmt), @nospecialize(typ))
-    push!(block.body, (idx, stmt, typ))
+function Base.push!(block::Block, idx::Int, @nospecialize(stmt), @nospecialize(typ),
+                    flag::UInt32=UInt32(0))
+    push!(block.body, (idx, stmt, typ, flag))
     # Set parent on sub-blocks when a CF op is inserted (like LLVM's addNodeToList)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
@@ -350,7 +390,8 @@ Base.eltype(::Type{InstructionIterator}) = Instruction
 function Base.iterate(it::InstructionIterator, state::Int=1)
     m = it.block.body
     state > length(m.ssa_idxes) && return nothing
-    inst = Instruction(m.ssa_idxes[state], m.stmts[state], m.types[state], it.block)
+    inst = Instruction(m.ssa_idxes[state], m.stmts[state], m.types[state],
+                       m.flags[state], it.block)
     return inst, state + 1
 end
 
@@ -608,6 +649,10 @@ function StructuredIRCode(ir::IRCode; structurize::Bool=true, validate::Bool=tru
     sptypes = copy(ir.sptypes)
     stmts = ir.stmts.stmt
     types = ir.stmts.type
+    # Per-statement IR_FLAG_* bitmask (see Compiler/src/optimize.jl). Inference
+    # and the inliner populate this with effect-freeness, nothrow, etc.; we
+    # carry it through so SCI passes can consult effects without re-deriving.
+    flags = ir.stmts.flag
     n = length(stmts)
 
     # Capture debug info: negative values = direct reference into table
@@ -633,7 +678,7 @@ function StructuredIRCode(ir::IRCode; structurize::Bool=true, validate::Bool=tru
         if stmt isa ReturnNode
             entry.terminator = stmt
         else
-            push!(entry, i, stmt, types[i])
+            push!(entry, i, stmt, types[i], flags[i])
         end
     end
 

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -49,42 +49,47 @@ function Base.delete!(block::Block, inst::Instruction)
 end
 
 """
-    push!(block::Block, stmt, typ) -> Instruction
+    push!(block::Block, stmt, typ; flag=0) -> Instruction
 
 Append a new instruction to the block, auto-allocating an SSA index.
-Requires `block.parent` to be set (see `_set_parent!`).
+Requires `block.parent` to be set (see `_set_parent!`). Optional `flag` is
+the per-statement `IR_FLAG_*` bitmask (defaults to 0 / `IR_FLAG_NULL`);
+keyword-only to avoid ambiguity with the explicit-idx `push!(block, idx, stmt, typ)`.
 """
-function Base.push!(block::Block, @nospecialize(stmt), @nospecialize(typ))
+function Base.push!(block::Block, @nospecialize(stmt), @nospecialize(typ);
+                    flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    push!(block.body, (idx, stmt, typ))
+    push!(block.body, (idx, stmt, typ, flag))
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, block)
+    return Instruction(idx, stmt, typ, flag, block)
 end
 
 """
-    pushfirst!(block::Block, stmt, typ) -> Instruction
+    pushfirst!(block::Block, stmt, typ; flag=0) -> Instruction
 
 Prepend a new instruction at the beginning of the block, auto-allocating an SSA index.
 """
-function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(typ))
+function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(typ);
+                         flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     pushfirst!(block.body.ssa_idxes, idx)
     pushfirst!(block.body.stmts, stmt)
     pushfirst!(block.body.types, typ)
+    pushfirst!(block.body.flags, flag)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, block)
+    return Instruction(idx, stmt, typ, flag, block)
 end
 
 """
@@ -154,81 +159,89 @@ function new_block_arg!(block::Block, @nospecialize(typ))
 end
 
 """
-    insert_before!(block::Block, ref::Instruction, stmt, typ) -> Instruction
+    insert_before!(block::Block, ref::Instruction, stmt, typ; flag=0) -> Instruction
 
 Insert a new instruction before `ref`, auto-allocating an SSA index.
 """
-function insert_before!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ))
+function insert_before!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ);
+                        flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_before_idx!(block.body, ref.ssa_idx, idx, stmt, typ)
-    return Instruction(idx, stmt, typ, block)
+    insert_before_idx!(block.body, ref.ssa_idx, idx, stmt, typ, flag)
+    return Instruction(idx, stmt, typ, flag, block)
 end
 
-function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, typ)
+function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, typ,
+                            flag::UInt32=UInt32(0))
     pos = findfirst(==(before_idx), m.ssa_idxes)
     pos === nothing && throw(KeyError(before_idx))
     insert!(m.ssa_idxes, pos, new_idx)
     insert!(m.stmts, pos, stmt)
     insert!(m.types, pos, typ)
+    insert!(m.flags, pos, flag)
 end
 
 """
-    insert_after!(block::Block, ref::Instruction, stmt, typ) -> Instruction
+    insert_after!(block::Block, ref::Instruction, stmt, typ; flag=0) -> Instruction
 
 Insert a new instruction after `ref`, auto-allocating an SSA index.
 """
-function insert_after!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ))
+function insert_after!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ);
+                       flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_after_idx!(block.body, ref.ssa_idx, idx, stmt, typ)
-    return Instruction(idx, stmt, typ, block)
+    insert_after_idx!(block.body, ref.ssa_idx, idx, stmt, typ, flag)
+    return Instruction(idx, stmt, typ, flag, block)
 end
 
-function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, typ)
+function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, typ,
+                           flag::UInt32=UInt32(0))
     pos = findfirst(==(after_idx), m.ssa_idxes)
     pos === nothing && throw(KeyError(after_idx))
     insert!(m.ssa_idxes, pos + 1, new_idx)
     insert!(m.stmts, pos + 1, stmt)
     insert!(m.types, pos + 1, typ)
+    insert!(m.flags, pos + 1, flag)
 end
 
 """
-    insert_before!(block::Block, ref::SSAValue, stmt, typ) -> Instruction
+    insert_before!(block::Block, ref::SSAValue, stmt, typ; flag=0) -> Instruction
 
 Insert a new instruction before the instruction at SSA index `ref.id`.
 """
-function insert_before!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(typ))
+function insert_before!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(typ);
+                        flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_before_idx!(block.body, ref.id, idx, stmt, typ)
+    insert_before_idx!(block.body, ref.id, idx, stmt, typ, flag)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, block)
+    return Instruction(idx, stmt, typ, flag, block)
 end
 
 """
-    insert_after!(block::Block, ref::SSAValue, stmt, typ) -> Instruction
+    insert_after!(block::Block, ref::SSAValue, stmt, typ; flag=0) -> Instruction
 
 Insert a new instruction after the instruction at SSA index `ref.id`.
 """
-function insert_after!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(typ))
+function insert_after!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(typ);
+                       flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_after_idx!(block.body, ref.id, idx, stmt, typ)
+    insert_after_idx!(block.body, ref.id, idx, stmt, typ, flag)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, block)
+    return Instruction(idx, stmt, typ, flag, block)
 end
 
 

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -285,7 +285,7 @@ end
 
 function merge_block_into!(dst::Block, src::Block)
     for (idx, entry) in src.body
-        push!(dst.body, (idx, entry.stmt, entry.typ))
+        push!(dst.body, (idx, entry.stmt, entry.typ, entry.flag))
     end
     if src.terminator !== nothing && dst.terminator === nothing
         dst.terminator = src.terminator

--- a/src/structurize/promote.jl
+++ b/src/structurize/promote.jl
@@ -32,7 +32,7 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
             if result isa ForOp
                 for_promotions[idx] = (removed, result, redirect)
                 carry_types = Any[t for (i, t) in enumerate(entry.typ.parameters) if i ∉ removed]
-                push!(new_body, (idx, result, Tuple{carry_types...}))
+                push!(new_body, (idx, result, Tuple{carry_types...}, entry.flag))
             else
                 # Fall back to existing path: LoopOp → WhileOp → ForOp
                 promoted = try_promote_while(stmt, ctx)
@@ -41,12 +41,12 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                     if result2 isa ForOp && iv_pos > 0
                         for_promotions[idx] = ([iv_pos], result2, Dict{Int,Int}())
                         carry_types = Any[t for (i, t) in enumerate(entry.typ.parameters) if i != iv_pos]
-                        push!(new_body, (idx, result2, Tuple{carry_types...}))
+                        push!(new_body, (idx, result2, Tuple{carry_types...}, entry.flag))
                     else
-                        push!(new_body, (idx, result2, entry.typ))
+                        push!(new_body, (idx, result2, entry.typ, entry.flag))
                     end
                 else
-                    push!(new_body, (idx, stmt, entry.typ))
+                    push!(new_body, (idx, stmt, entry.typ, entry.flag))
                 end
             end
         elseif stmt isa Expr && stmt.head === :call && stmt.args[1] === Core.getfield &&
@@ -61,22 +61,22 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                     # Duplicate carry → redirect to surviving carry's adjusted index
                     adjusted = target_pos - count(p -> p < target_pos, removed)
                     new_gf = Expr(:call, Core.getfield, SSAValue(loop_ssa), adjusted)
-                    push!(new_body, (idx, new_gf, entry.typ))
+                    push!(new_body, (idx, new_gf, entry.typ, entry.flag))
                 else
-                    push!(new_body, (idx, for_op.upper, entry.typ))
+                    push!(new_body, (idx, for_op.upper, entry.typ, entry.flag))
                 end
             else
                 adjusted = field_idx - count(p -> p < field_idx, removed)
                 new_gf = Expr(:call, Core.getfield, SSAValue(loop_ssa), adjusted)
-                push!(new_body, (idx, new_gf, entry.typ))
+                push!(new_body, (idx, new_gf, entry.typ, entry.flag))
             end
         elseif stmt isa ControlFlowOp
             for b in blocks(stmt)
                 promote_loops!(b, ctx)
             end
-            push!(new_body, (idx, stmt, entry.typ))
+            push!(new_body, (idx, stmt, entry.typ, entry.flag))
         else
-            push!(new_body, (idx, stmt, entry.typ))
+            push!(new_body, (idx, stmt, entry.typ, entry.flag))
         end
     end
     block.body = new_body
@@ -192,13 +192,13 @@ function simplify_loop_exit(body::Block)
     # Build merged IfOp: inner condition true → done → break, false → continue
     merged_then = Block()
     for (sidx, sentry) in done_body_region.body
-        push!(merged_then.body, (sidx, sentry.stmt, sentry.typ))
+        push!(merged_then.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
     merged_then.terminator = BreakOp(break_values)
 
     merged_else = Block()
     for (sidx, sentry) in cont_body_region.body
-        push!(merged_else.body, (sidx, sentry.stmt, sentry.typ))
+        push!(merged_else.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
     merged_else.terminator = ContinueOp(cont_values)
 
@@ -211,7 +211,7 @@ function simplify_loop_exit(body::Block)
     end
     for (sidx, sentry) in body.body
         sidx == inner_result.id && break
-        push!(result.body, (sidx, sentry.stmt, sentry.typ))
+        push!(result.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
     push!(result.body, (outer_idx, merged_if, Tuple{}))
     return result
@@ -427,11 +427,11 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
     last_idx = body.body.ssa_idxes[end]
     for (sidx, sentry) in body.body
         sidx == last_idx && break
-        push!(for_body.body, (sidx, sentry.stmt, sentry.typ))
+        push!(for_body.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
     for (sidx, sentry) in cont_region.body
         step_ssa !== nothing && sidx == step_ssa && continue  # skip IV increment
-        push!(for_body.body, (sidx, sentry.stmt, sentry.typ))
+        push!(for_body.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
 
     # ContinueOp with non-IV, non-shadow values
@@ -506,7 +506,7 @@ function try_promote_while(loop::LoopOp, ctx::StructurizeCtx)
     before = Block()
     for (i, (sidx, sentry)) in enumerate(body.body)
         sidx == last_idx && break
-        push!(before.body, (sidx, sentry.stmt, sentry.typ))
+        push!(before.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
     for arg in body.args
         push!(before.args, arg)
@@ -525,7 +525,7 @@ function try_promote_while(loop::LoopOp, ctx::StructurizeCtx)
         arg_remap[arg.id] = after_arg
     end
     for (sidx, sentry) in stay_region.body
-        push!(after.body, (sidx, sentry.stmt, sentry.typ))
+        push!(after.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
     after.terminator = YieldOp(copy(continue_op.values))
 
@@ -667,7 +667,7 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
         if carried_val isa SSAValue && sidx == carried_val.id
             continue
         end
-        push!(for_body.body, (sidx, sentry.stmt, sentry.typ))
+        push!(for_body.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
     end
 
     # ContinueOp with non-IV carried values
@@ -703,7 +703,7 @@ function remap_block_args!(block::Block, remap::Dict{Int, BlockArgument})
     new_body = SSAMap()
     for (idx, entry) in block.body
         new_stmt = remap_value(entry.stmt, remap)
-        push!(new_body, (idx, new_stmt, entry.typ))
+        push!(new_body, (idx, new_stmt, entry.typ, entry.flag))
     end
     block.body = new_body
     if block.terminator !== nothing

--- a/src/structurize/substitutions.jl
+++ b/src/structurize/substitutions.jl
@@ -66,10 +66,10 @@ function apply_substitutions!(block::Block, subs::Substitutions, ctx)
     for (idx, entry) in block.body
         if entry.stmt isa ControlFlowOp
             apply_substitutions!(entry.stmt, subs, ctx)
-            push!(new_body, (idx, entry.stmt, entry.typ))
+            push!(new_body, (idx, entry.stmt, entry.typ, entry.flag))
         else
             new_expr = substitute_ssa(entry.stmt, subs)
-            push!(new_body, (idx, new_expr, entry.typ))
+            push!(new_body, (idx, new_expr, entry.typ, entry.flag))
         end
     end
     block.body = new_body

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -145,7 +145,7 @@ function emit_block_stmts!(block::Block, ctx::StructurizeCtx, bb_idx::Int)
          stmt isa GotoIfNot || stmt isa ReturnNode) && continue
         idx = get(remap, si, si)
         stmt = remap_stmt(stmt, remap)
-        push!(block, idx, stmt, ir.stmts.type[si])
+        push!(block, idx, stmt, ir.stmts.type[si], ir.stmts.flag[si])
         idx != si && anchor_line!(ctx, idx, si)
     end
 end
@@ -402,7 +402,7 @@ function tail_duplicate_branch!(b::Block, dest::Int,
     ctx.ssa_remap = saved_remap
 
     for (idx, entry) in sub_block.body
-        push!(b.body, (idx, entry.stmt, entry.typ))
+        push!(b.body, (idx, entry.stmt, entry.typ, entry.flag))
     end
     b.terminator = sub_block.terminator
     return b

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -14,10 +14,29 @@
     @test !isempty(insts)
     @test all(i -> i isa Instruction, insts)
 
-    # Each Instruction bundles ssa_idx, stmt, typ
+    # Each Instruction bundles ssa_idx, stmt, typ, flag
     inst = first(insts)
     @test value_type(inst) isa Type
     @test SSAValue(inst) isa SSAValue
+    @test inst.flag isa UInt32
+end
+
+@testset "per-stmt flag carried through from IRCode" begin
+    # `Base.add_int(x, 1)` is pure: inference + the inliner mark its
+    # statement with `IR_FLAG_EFFECT_FREE`. The structurizer reads
+    # `ir.stmts.flag[i]` at ingestion, so that bit must be observable
+    # on the resulting Instruction.
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+    found_pure = false
+    for inst in instructions(sci.entry)
+        s = stmt(inst)
+        if s isa Expr && s.head === :call
+            (inst.flag & Core.Compiler.IR_FLAG_EFFECT_FREE) != 0 && (found_pure = true; break)
+        end
+    end
+    @test found_pure
 end
 
 @testset "arguments(block)" begin
@@ -306,7 +325,7 @@ end
         x + 1
     end |> only
 
-    bad_ref = Instruction(999999, nothing, Nothing, Block())
+    bad_ref = Instruction(999999, nothing, Nothing, UInt32(0), Block())
     @test_throws KeyError insert_before!(sci.entry, bad_ref, Expr(:call, :x), Int)
 end
 
@@ -362,7 +381,7 @@ end
     @test found === sci.entry
 
     # Non-existent instruction returns nothing
-    @test findblock(sci, Instruction(999999, nothing, Nothing, Block())) === nothing
+    @test findblock(sci, Instruction(999999, nothing, Nothing, UInt32(0), Block())) === nothing
 end
 
 @testset "reachable_terminators(block)" begin
@@ -1071,7 +1090,7 @@ end  # loop carries
     @test resolve_call(block, Expr(:new, :Foo)) === nothing
 
     # Instruction overload
-    inst = Instruction(1, expr_call, Int, Block())
+    inst = Instruction(1, expr_call, Int, UInt32(0), Block())
     result3 = resolve_call(block, inst)
     @test result3 !== nothing
     @test first(result3) === Base.:+
@@ -1137,7 +1156,7 @@ end
     @test !iscall(Expr(:new, :Foo))
 
     # Instruction overloads
-    inst = Instruction(1, expr_call, Int, Block())
+    inst = Instruction(1, expr_call, Int, UInt32(0), Block())
     @test iscall(inst)
     @test callee(inst) == GlobalRef(Base, :+)
     @test length(callargs(inst)) == 2


### PR DESCRIPTION
Julia inference + the inliner populate `IRCode.stmts.flag` with the per-statement effect bits (`IR_FLAG_EFFECT_FREE`, `IR_FLAG_NOTHROW`, `IR_FLAG_TERMINATES`, …; see `Compiler/src/optimize.jl`). These are the ground-truth source for "is this op pure" and friends, but until now `StructuredIRCode` dropped them at ingestion — every downstream pass had to re-derive purity through hardcoded function lists, which is fragile and a layering violation (cuTile's `RNG_FUNCS`, `classify_memory_op` return-type sniffs, etc.).

`SSAMap` gains a 4th parallel slot `flags::Vector{UInt32}`; `Instruction` gains a `flag::UInt32` field. The IRCode ingestion site reads `ir.stmts.flag[i]` alongside stmt and type, and the structurizer's relocation sites (`merge_block_into!`, `apply_substitutions!`, `promote_loops!`, `try_promote_for*`, `try_promote_while`, `remap_block_args!`, branch-merge body copies) preserve `entry.flag` when copying through. Synthesized statements (the `add_int` for ForOp upper-bound adjustment) default to `IR_FLAG_NULL` (0).

The existing `Instruction(idx, stmt, typ, block)` 4-arg constructor is preserved as a compat shim defaulting `flag=IR_FLAG_NULL`, so downstream packages don't need to update call sites for this change. The auto-allocating `push!`/`pushfirst!`/`insert_before!`/`insert_after!` helpers grow a `; flag` keyword (kwarg, not positional, to avoid an ambiguity with the explicit-idx `push!(block, idx::Int, stmt, typ)` when stmt happens to be `Int`).

Adds a regression test that verifies `IR_FLAG_EFFECT_FREE` survives the round trip from `Base.code_ircode` → `StructuredIRCode` for a pure call.