### PR TITLE
Make `Instruction` a handle, aligned with `Core.Compiler.Instruction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,17 @@ Check if a value is defined in this block. Returns `true` for `SSAValue`s in the
 
 Check whether a value is defined outside a block (and all its descendants), or outside a loop operation's regions. The loop-op overloads handle values like `ForOp.iv_arg` that aren't in the body's block args. Analogous to MLIR's `LoopLikeOpInterface::isDefinedOutsideOfLoop`.
 
-#### `update_type!(block, inst, new_type)`
+#### `block[ssa_idx]` → `Instruction` / `block[ssa_idx] = (...)`
 
-Change the type annotation of an existing instruction.
+Access or mutate the entry at an SSA index. `block[idx]` returns the `Instruction` handle (throws `KeyError` if absent — pair with `haskey(block, idx)`). `block[idx] = nt` accepts any NamedTuple subset of `(stmt, type, flag)`; fields not mentioned are preserved. So `block[idx] = (type=Float64,)` overwrites only the type, keeping `stmt` and `flag`.
 
-#### `new_block_arg!(block, typ)` → `BlockArg`
+#### `inst[:stmt]` / `inst[:type]` / `inst[:flag]` (Symbol-keyed access)
+
+Read or write a single field of an instruction's live entry. Modeled on `Core.Compiler.Instruction` (`Compiler/src/ssair/ir.jl`). Reads and writes go through the block's storage, so `inst[:type] = T; inst[:type]` round-trips. `inst[:ssa_idx]` and `inst[:block]` are also exposed.
+
+When swapping `:stmt` for one with a different opcode, the old `flag` bits describe the OLD op and may be stale for the new one. Pass `inst[:flag] = IR_FLAG_NULL` (or `block[idx] = (stmt=…, flag=IR_FLAG_NULL)` for an atomic write), mirroring LLVM's "fresh instruction, then opt-in `copyIRFlags`" pattern.
+
+#### `new_block_arg!(block, type)` → `BlockArg`
 
 Add a new `BlockArg` to a block.
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Iterate over instructions in a block as `Inst` objects. Each `Inst` bundles an S
 
 ```julia
 for inst in instructions(block)
-    stmt(inst)       # underlying statement (Expr, ControlFlowOp, etc.)
-    value_type(inst) # Julia type of the instruction result
+    inst[:stmt]      # underlying statement (Expr, ControlFlowOp, etc.)
+    inst[:type]      # Julia type of the instruction result (or value_type(inst))
+    inst[:flag]      # IR_FLAG_* bitmask (see Compiler/src/optimize.jl)
+    inst.block       # containing block
 end
 ```
 
@@ -142,8 +144,8 @@ Pre-built index for O(1) definition lookup. Analogous to `uses(block)` which ret
 idx = defs(sci)
 inst = def(idx, SSAValue(3))
 if inst !== nothing
-    stmt(inst)        # the statement
-    block(inst)       # the containing block
+    inst[:stmt]       # the statement
+    inst.block        # the containing block
 end
 ```
 

--- a/src/ir/show.jl
+++ b/src/ir/show.jl
@@ -381,9 +381,9 @@ function print_block_body(p::IRPrinter, block::Block; is_last_in_parent::Bool=fa
     items = []
     for (i, (idx, entry)) in enumerate(block.body)
         if entry.stmt isa ControlFlowOp
-            push!(items, (:nested, idx, entry.stmt, entry.typ))
+            push!(items, (:nested, idx, entry.stmt, entry.type))
         else
-            push!(items, (:expr, idx, entry.stmt, entry.typ))
+            push!(items, (:expr, idx, entry.stmt, entry.type))
         end
     end
     if block.terminator !== nothing

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -66,7 +66,7 @@ Analogous to MLIR's `Operation` which knows its parent `Block` via `getBlock()`.
 struct Instruction
     ssa_idx::Int
     stmt::Any
-    typ::Any
+    type::Any
     flag::UInt32  # IR_FLAG_* bitmask from Julia inference; 0 (IR_FLAG_NULL) if synthesized
     block::Any  # ::Block — untyped to avoid forward reference
 end
@@ -74,11 +74,11 @@ end
 # Convenience: construct without an explicit flag (defaults to IR_FLAG_NULL).
 # Matches the pre-`flag` constructor signature for callers that don't yet
 # carry per-stmt flags through.
-Instruction(ssa_idx::Int, @nospecialize(stmt), @nospecialize(typ), @nospecialize(block)) =
-    Instruction(ssa_idx, stmt, typ, UInt32(0), block)
+Instruction(ssa_idx::Int, @nospecialize(stmt), @nospecialize(type), @nospecialize(block)) =
+    Instruction(ssa_idx, stmt, type, UInt32(0), block)
 
 """Get the Julia type of the instruction result."""
-value_type(i::Instruction) = i.typ
+value_type(i::Instruction) = i.type
 
 """Get the underlying statement (Expr, ControlFlowOp, etc.)."""
 stmt(i::Instruction) = i.stmt
@@ -112,23 +112,24 @@ end
 =============================================================================#
 
 """
-    SSAMap <: AbstractDict{Int, NamedTuple{(:stmt, :typ, :flag)}}
+    SSAMap <: AbstractDict{Int, NamedTuple{(:stmt, :type, :flag)}}
 
-An ordered map from SSA indices to `(; stmt, typ, flag)` entries.
+An ordered map from SSA indices to `(; stmt, type, flag)` entries.
 Used to store block body contents with their original Julia SSA indices.
 
 `flag` is the per-statement `IR_FLAG_*` bitmask carried over from
 `IRCode.stmts.flag` at structurization (see `Compiler/src/optimize.jl`),
 or `0` (`IR_FLAG_NULL`) for statements synthesized after structurization.
 
-Indexing by SSA index: `m[ssa_idx]` returns `(; stmt, typ, flag)` or throws `KeyError`,
-`get(m, ssa_idx, default)` returns `default` if missing.
-Iteration yields `idx => (; stmt, typ, flag)` pairs.
+Indexing by SSA index: `m[ssa_idx]` returns `(; stmt, type, flag)` or throws `KeyError`,
+`get(m, ssa_idx, default)` returns `default` if missing. `setindex!` accepts any
+NamedTuple subset of `(stmt, type, flag)` — fields not mentioned are preserved.
+Iteration yields `idx => (; stmt, type, flag)` pairs.
 
 Note: Currently uses linear scan for lookup. If this becomes a bottleneck,
 consider switching to `OrderedDict{Int, NamedTuple}` for O(1) access.
 """
-struct SSAMap <: AbstractDict{Int, @NamedTuple{stmt::Any, typ::Any, flag::UInt32}}
+struct SSAMap <: AbstractDict{Int, @NamedTuple{stmt::Any, type::Any, flag::UInt32}}
     ssa_idxes::Vector{Int}
     stmts::Vector{Any}
     types::Vector{Any}
@@ -137,11 +138,11 @@ end
 
 SSAMap() = SSAMap(Int[], Any[], Any[], UInt32[])
 
-# Iteration yields idx => (; stmt, typ, flag) pairs
+# Iteration yields idx => (; stmt, type, flag) pairs
 function Base.iterate(m::SSAMap, state::Int=1)
     state > length(m.ssa_idxes) && return nothing
     idx = m.ssa_idxes[state]
-    entry = (; stmt=m.stmts[state], typ=m.types[state], flag=m.flags[state])
+    entry = (; stmt=m.stmts[state], type=m.types[state], flag=m.flags[state])
     return Pair(idx, entry), state + 1
 end
 
@@ -152,13 +153,13 @@ Base.haskey(m::SSAMap, ssa_idx::Int) = findfirst(==(ssa_idx), m.ssa_idxes) !== n
 function Base.getindex(m::SSAMap, ssa_idx::Int)
     i = findfirst(==(ssa_idx), m.ssa_idxes)
     i === nothing && throw(KeyError(ssa_idx))
-    return (; stmt=m.stmts[i], typ=m.types[i], flag=m.flags[i])
+    return (; stmt=m.stmts[i], type=m.types[i], flag=m.flags[i])
 end
 
 function Base.get(m::SSAMap, ssa_idx::Int, default)
     i = findfirst(==(ssa_idx), m.ssa_idxes)
     i === nothing && return default
-    return (; stmt=m.stmts[i], typ=m.types[i], flag=m.flags[i])
+    return (; stmt=m.stmts[i], type=m.types[i], flag=m.flags[i])
 end
 
 # Push raw tuple. The 3-tuple form defaults the flag to IR_FLAG_NULL (0) — used
@@ -166,14 +167,14 @@ end
 # The 4-tuple form takes an explicit flag and is used by the IRCode ingestion
 # site (and by structurizer-internal sites that *relocate* an existing stmt and
 # want to preserve its flag).
-function Base.push!(m::SSAMap, (idx, stmt, typ)::Tuple{Int,Any,Any})
-    push!(m, (idx, stmt, typ, UInt32(0)))
+function Base.push!(m::SSAMap, (idx, stmt, type)::Tuple{Int,Any,Any})
+    push!(m, (idx, stmt, type, UInt32(0)))
 end
 
-function Base.push!(m::SSAMap, (idx, stmt, typ, flag)::Tuple{Int,Any,Any,UInt32})
+function Base.push!(m::SSAMap, (idx, stmt, type, flag)::Tuple{Int,Any,Any,UInt32})
     push!(m.ssa_idxes, idx)
     push!(m.stmts, stmt)
-    push!(m.types, typ)
+    push!(m.types, type)
     push!(m.flags, flag)
     return nothing
 end
@@ -184,22 +185,17 @@ statements(m::SSAMap) = (stmt for stmt in m.stmts)
 types(m::SSAMap) = (typ for typ in m.types)
 flags(m::SSAMap) = (f for f in m.flags)
 
-# Mutation: setindex! for replacing a statement in-place. Two-field form
-# preserves the existing flag; three-field form overwrites it.
-function Base.setindex!(m::SSAMap, entry::NamedTuple{(:stmt, :typ)}, ssa_idx::Int)
+# Mutation: setindex! accepts any NamedTuple subset of (stmt, type, flag).
+# Fields not mentioned are preserved — `m[idx] = (type=Float64,)` overwrites
+# only the type, keeping stmt and flag.
+function Base.setindex!(m::SSAMap, entry::NamedTuple{names}, ssa_idx::Int) where {names}
+    names ⊆ (:stmt, :type, :flag) ||
+        throw(ArgumentError("SSAMap entry keys must be a subset of (:stmt, :type, :flag), got $names"))
     i = findfirst(==(ssa_idx), m.ssa_idxes)
     i === nothing && throw(KeyError(ssa_idx))
-    m.stmts[i] = entry.stmt
-    m.types[i] = entry.typ
-    return entry
-end
-
-function Base.setindex!(m::SSAMap, entry::NamedTuple{(:stmt, :typ, :flag)}, ssa_idx::Int)
-    i = findfirst(==(ssa_idx), m.ssa_idxes)
-    i === nothing && throw(KeyError(ssa_idx))
-    m.stmts[i] = entry.stmt
-    m.types[i] = entry.typ
-    m.flags[i] = entry.flag
+    haskey(entry, :stmt) && (m.stmts[i] = entry.stmt)
+    haskey(entry, :type) && (m.types[i] = entry.type)
+    haskey(entry, :flag) && (m.flags[i] = entry.flag)
     return entry
 end
 
@@ -298,7 +294,7 @@ abstract type ControlFlowOp end
     Block
 
 A block of statements with block arguments and a terminator.
-Body is an SSAMap mapping SSA indices to (stmt, type) entries.
+Body is an SSAMap mapping SSA indices to (; stmt, type, flag) entries.
 """
 mutable struct Block
     args::Vector{BlockArgument}
@@ -320,14 +316,14 @@ function Base.empty!(block::Block)
 end
 
 """
-    push!(block::Block, idx::Int, stmt, typ, [flag])
+    push!(block::Block, idx::Int, stmt, type, [flag])
 
 Push a statement or control flow op to a block with its SSA index, type, and
 optional `IR_FLAG_*` bitmask (defaults to 0 / `IR_FLAG_NULL`).
 """
-function Base.push!(block::Block, idx::Int, @nospecialize(stmt), @nospecialize(typ),
+function Base.push!(block::Block, idx::Int, @nospecialize(stmt), @nospecialize(type),
                     flag::UInt32=UInt32(0))
-    push!(block.body, (idx, stmt, typ, flag))
+    push!(block.body, (idx, stmt, type, flag))
     # Set parent on sub-blocks when a CF op is inserted (like LLVM's addNodeToList)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
@@ -353,17 +349,17 @@ function Base.show(io::IO, block::Block)
     if !isempty(block.args)
         print(io, "args=", length(block.args), ", ")
     end
-    n_ops = count(((_, item, _),) -> item isa ControlFlowOp, block.body)
+    n_ops = count(p -> last(p).stmt isa ControlFlowOp, block.body)
     n_exprs = length(block.body) - n_ops
     print(io, n_exprs + n_ops, " items")
     print(io, ")")
 end
 
-# Iteration protocol for Block - yields (idx, stmt, typ) triples (legacy)
+# Iteration protocol for Block - delegates to SSAMap, yielding idx => (; stmt, type, flag)
 Base.iterate(block::Block) = iterate(block.body)
 Base.iterate(block::Block, state) = iterate(block.body, state)
 Base.length(block::Block) = length(block.body)
-Base.eltype(::Type{Block}) = Tuple{Int,Any,Any}
+Base.eltype(::Type{Block}) = eltype(SSAMap)
 
 #=============================================================================
  Block accessors (LLVM.jl-style)

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -51,57 +51,6 @@ Base.show(io::IO, u::Undef) = print(io, "undef::$(u.type)")
 const IRValue = Any
 
 #=============================================================================
- Instruction - convenience view over an SSAMap entry
-=============================================================================#
-
-"""
-    Instruction
-
-A handle into an SSAMap entry: an SSA index paired with the containing
-`Block`. Field reads/writes go through the live `Block.body` entry, so a
-handle held across mutations always sees the current `(stmt, type, flag)`.
-
-Yielded by `instructions(block)` and usable as a key in `UseIndex`.
-
-Field access is Symbol-keyed: `inst[:stmt]`, `inst[:type]`, `inst[:flag]`
-read the live entry; `inst[:stmt] = …` etc. write back. The containing
-block is `inst.block`; the SSA index is `inst.ssa_idx`. The polymorphic
-`value_type(inst)` is a convenience for `inst[:type]` and also accepts
-non-Instruction values (`SSAValue`, `BlockArgument`, …).
-
-Analogous to `Core.Compiler.Instruction` in `Compiler/src/ssair/ir.jl`,
-which is also a `(storage, key)` handle dispatching to parallel field
-vectors via `node[:stmt]` etc. — the difference being that the storage
-here is keyed by SSA index (preserved across structurization) rather
-than by dense position. Becomes stale on `delete!` of the underlying
-entry; identity (`==`, `hash`) is by `ssa_idx` only.
-"""
-struct Instruction
-    ssa_idx::Int
-    block::Any  # ::Block — untyped to avoid forward reference
-end
-
-"""Get the Julia type of the instruction result."""
-value_type(i::Instruction) = i[:type]
-
-"""Convert to SSAValue for use in operand positions."""
-Core.SSAValue(i::Instruction) = SSAValue(i.ssa_idx)
-
-Base.:(==)(a::Instruction, b::Instruction) = a.ssa_idx == b.ssa_idx
-Base.hash(i::Instruction, h::UInt) = hash(i.ssa_idx, h)
-
-function Base.show(io::IO, i::Instruction)
-    print(io, "Instruction(%$(i.ssa_idx)")
-    s = i[:stmt]
-    if s isa ControlFlowOp
-        print(io, " = ", typeof(s))
-    elseif s isa Expr
-        print(io, " = ", s.head, "(...)")
-    end
-    print(io, ")")
-end
-
-#=============================================================================
  SSAMap - ordered map from SSA index to (stmt, type)
 =============================================================================#
 
@@ -362,6 +311,60 @@ Base.iterate(block::Block) = iterate(block.body)
 Base.iterate(block::Block, state) = iterate(block.body, state)
 Base.length(block::Block) = length(block.body)
 Base.eltype(::Type{Block}) = eltype(SSAMap)
+
+#=============================================================================
+ Instruction - handle into an SSAMap entry
+=============================================================================#
+
+"""
+    Instruction
+
+A handle into an SSAMap entry: an SSA index paired with the containing
+`Block`. Field reads/writes go through the live `Block.body` entry, so a
+handle held across mutations always sees the current `(stmt, type, flag)`.
+
+Yielded by `instructions(block)` and usable as a key in `UseIndex`.
+
+Field access is Symbol-keyed: `inst[:stmt]`, `inst[:type]`, `inst[:flag]`
+read the live entry; `inst[:stmt] = …` etc. write back. The containing
+block is `inst.block`; the SSA index is `inst.ssa_idx`. The polymorphic
+`value_type(inst)` is a convenience for `inst[:type]` and also accepts
+non-Instruction values (`SSAValue`, `BlockArgument`, …).
+
+Analogous to `Core.Compiler.Instruction` in `Compiler/src/ssair/ir.jl`,
+which is also a `(storage, key)` handle dispatching to parallel field
+vectors via `node[:stmt]` etc. — the difference being that the storage
+here is keyed by SSA index (preserved across structurization) rather
+than by dense position. Becomes stale on `delete!` of the underlying
+entry; identity (`==`, `hash`) is by `ssa_idx` only — sound because SSA
+indices are globally unique within a `StructuredIRCode` and never reused
+after `delete!` (allocated via `max_ssa_idx`, enforced by
+`validate_ssa_uniqueness`).
+"""
+struct Instruction
+    ssa_idx::Int
+    block::Block
+end
+
+"""Get the Julia type of the instruction result."""
+value_type(i::Instruction) = i[:type]
+
+"""Convert to SSAValue for use in operand positions."""
+Core.SSAValue(i::Instruction) = SSAValue(i.ssa_idx)
+
+Base.:(==)(a::Instruction, b::Instruction) = a.ssa_idx == b.ssa_idx
+Base.hash(i::Instruction, h::UInt) = hash(i.ssa_idx, h)
+
+function Base.show(io::IO, i::Instruction)
+    print(io, "Instruction(%$(i.ssa_idx)")
+    s = i[:stmt]
+    if s isa ControlFlowOp
+        print(io, " = ", typeof(s))
+    elseif s isa Expr
+        print(io, " = ", s.head, "(...)")
+    end
+    print(io, ")")
+end
 
 #=============================================================================
  Block accessors (LLVM.jl-style)

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -126,17 +126,19 @@ Indexing by SSA index: `m[ssa_idx]` returns `(; stmt, type, flag)` or throws `Ke
 NamedTuple subset of `(stmt, type, flag)` — fields not mentioned are preserved.
 Iteration yields `idx => (; stmt, type, flag)` pairs.
 
-Note: Currently uses linear scan for lookup. If this becomes a bottleneck,
-consider switching to `OrderedDict{Int, NamedTuple}` for O(1) access.
+Storage is parallel `Vector`s (analogous to `Core.Compiler.InstructionStream`
+in `Compiler/src/ssair/ir.jl`), with a side `pos_by_idx::Dict{Int,Int}`
+giving O(1) lookup from SSA index to vector position.
 """
 struct SSAMap <: AbstractDict{Int, @NamedTuple{stmt::Any, type::Any, flag::UInt32}}
     ssa_idxes::Vector{Int}
     stmts::Vector{Any}
     types::Vector{Any}
     flags::Vector{UInt32}  # IR_FLAG_* bitmask per stmt; parallel to stmts/types
+    pos_by_idx::Dict{Int, Int}  # ssa_idx → position in the parallel vectors
 end
 
-SSAMap() = SSAMap(Int[], Any[], Any[], UInt32[])
+SSAMap() = SSAMap(Int[], Any[], Any[], UInt32[], Dict{Int,Int}())
 
 # Iteration yields idx => (; stmt, type, flag) pairs
 function Base.iterate(m::SSAMap, state::Int=1)
@@ -147,18 +149,18 @@ function Base.iterate(m::SSAMap, state::Int=1)
 end
 
 Base.length(m::SSAMap) = length(m.ssa_idxes)
-Base.haskey(m::SSAMap, ssa_idx::Int) = findfirst(==(ssa_idx), m.ssa_idxes) !== nothing
+Base.haskey(m::SSAMap, ssa_idx::Int) = haskey(m.pos_by_idx, ssa_idx)
 
 # Lookup by SSA index
 function Base.getindex(m::SSAMap, ssa_idx::Int)
-    i = findfirst(==(ssa_idx), m.ssa_idxes)
-    i === nothing && throw(KeyError(ssa_idx))
+    i = get(m.pos_by_idx, ssa_idx, 0)
+    i == 0 && throw(KeyError(ssa_idx))
     return (; stmt=m.stmts[i], type=m.types[i], flag=m.flags[i])
 end
 
 function Base.get(m::SSAMap, ssa_idx::Int, default)
-    i = findfirst(==(ssa_idx), m.ssa_idxes)
-    i === nothing && return default
+    i = get(m.pos_by_idx, ssa_idx, 0)
+    i == 0 && return default
     return (; stmt=m.stmts[i], type=m.types[i], flag=m.flags[i])
 end
 
@@ -176,6 +178,7 @@ function Base.push!(m::SSAMap, (idx, stmt, type, flag)::Tuple{Int,Any,Any,UInt32
     push!(m.stmts, stmt)
     push!(m.types, type)
     push!(m.flags, flag)
+    m.pos_by_idx[idx] = length(m.ssa_idxes)
     return nothing
 end
 
@@ -191,8 +194,8 @@ flags(m::SSAMap) = (f for f in m.flags)
 function Base.setindex!(m::SSAMap, entry::NamedTuple{names}, ssa_idx::Int) where {names}
     names ⊆ (:stmt, :type, :flag) ||
         throw(ArgumentError("SSAMap entry keys must be a subset of (:stmt, :type, :flag), got $names"))
-    i = findfirst(==(ssa_idx), m.ssa_idxes)
-    i === nothing && throw(KeyError(ssa_idx))
+    i = get(m.pos_by_idx, ssa_idx, 0)
+    i == 0 && throw(KeyError(ssa_idx))
     haskey(entry, :stmt) && (m.stmts[i] = entry.stmt)
     haskey(entry, :type) && (m.types[i] = entry.type)
     haskey(entry, :flag) && (m.flags[i] = entry.flag)
@@ -201,12 +204,17 @@ end
 
 # Mutation: delete! for removing a statement
 function Base.delete!(m::SSAMap, ssa_idx::Int)
-    i = findfirst(==(ssa_idx), m.ssa_idxes)
-    i === nothing && throw(KeyError(ssa_idx))
+    i = get(m.pos_by_idx, ssa_idx, 0)
+    i == 0 && throw(KeyError(ssa_idx))
     deleteat!(m.ssa_idxes, i)
     deleteat!(m.stmts, i)
     deleteat!(m.types, i)
     deleteat!(m.flags, i)
+    delete!(m.pos_by_idx, ssa_idx)
+    # Positions after `i` have shifted down by one.
+    for j in i:length(m.ssa_idxes)
+        m.pos_by_idx[m.ssa_idxes[j]] = j
+    end
     return m
 end
 

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -80,15 +80,15 @@ struct Instruction
 end
 
 """Get the Julia type of the instruction result."""
-value_type(i::Instruction) = (i.block::Block).body[i.ssa_idx].type
+value_type(i::Instruction) = i[:type]
 
 """Get the underlying statement (Expr, ControlFlowOp, etc.)."""
-stmt(i::Instruction) = (i.block::Block).body[i.ssa_idx].stmt
+stmt(i::Instruction) = i[:stmt]
 
 """Get the per-statement IR flag bitmask (e.g. `IR_FLAG_EFFECT_FREE`).
 Carried through from `IRCode.stmts.flag` at structurization; 0 for stmts
 synthesized by the structurizer or by downstream passes."""
-flag(i::Instruction) = (i.block::Block).body[i.ssa_idx].flag
+flag(i::Instruction) = i[:flag]
 
 """Get the block containing this instruction."""
 block(i::Instruction) = i.block
@@ -101,7 +101,7 @@ Base.hash(i::Instruction, h::UInt) = hash(i.ssa_idx, h)
 
 function Base.show(io::IO, i::Instruction)
     print(io, "Instruction(%$(i.ssa_idx)")
-    s = stmt(i)
+    s = i[:stmt]
     if s isa ControlFlowOp
         print(io, " = ", typeof(s))
     elseif s isa Expr

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -1,6 +1,6 @@
 # structured IR definitions
 
-export StructuredIRCode, Undef, Instruction, instructions, arguments, value_type, stmt, flag, block,
+export StructuredIRCode, Undef, Instruction, instructions, arguments, value_type,
        insert_before!, insert_after!, terminator, terminator!, operands,
        source_location
 
@@ -63,9 +63,11 @@ handle held across mutations always sees the current `(stmt, type, flag)`.
 
 Yielded by `instructions(block)` and usable as a key in `UseIndex`.
 
-Use the Symbol-keyed accessors (`inst[:stmt]`, `inst[:type]`, `inst[:flag]`)
-for reads and writes; `value_type(inst)`, `stmt(inst)`, `flag(inst)`,
-`block(inst)` are convenience aliases.
+Field access is Symbol-keyed: `inst[:stmt]`, `inst[:type]`, `inst[:flag]`
+read the live entry; `inst[:stmt] = …` etc. write back. The containing
+block is `inst.block`; the SSA index is `inst.ssa_idx`. The polymorphic
+`value_type(inst)` is a convenience for `inst[:type]` and also accepts
+non-Instruction values (`SSAValue`, `BlockArgument`, …).
 
 Analogous to `Core.Compiler.Instruction` in `Compiler/src/ssair/ir.jl`,
 which is also a `(storage, key)` handle dispatching to parallel field
@@ -81,17 +83,6 @@ end
 
 """Get the Julia type of the instruction result."""
 value_type(i::Instruction) = i[:type]
-
-"""Get the underlying statement (Expr, ControlFlowOp, etc.)."""
-stmt(i::Instruction) = i[:stmt]
-
-"""Get the per-statement IR flag bitmask (e.g. `IR_FLAG_EFFECT_FREE`).
-Carried through from `IRCode.stmts.flag` at structurization; 0 for stmts
-synthesized by the structurizer or by downstream passes."""
-flag(i::Instruction) = i[:flag]
-
-"""Get the block containing this instruction."""
-block(i::Instruction) = i.block
 
 """Convert to SSAValue for use in operand positions."""
 Core.SSAValue(i::Instruction) = SSAValue(i.ssa_idx)

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -1,6 +1,6 @@
 # structured IR definitions
 
-export StructuredIRCode, Undef, Instruction, instructions, arguments, value_type, stmt, block,
+export StructuredIRCode, Undef, Instruction, instructions, arguments, value_type, stmt, flag, block,
        insert_before!, insert_after!, terminator, terminator!, operands,
        source_location
 
@@ -57,36 +57,38 @@ const IRValue = Any
 """
     Instruction
 
-A view over an SSAMap entry, bundling an SSA index with its statement, type,
-and containing block. Yielded by `instructions(block)` and usable as a key
-in `UseIndex`.
+A handle into an SSAMap entry: an SSA index paired with the containing
+`Block`. Field reads/writes go through the live `Block.body` entry, so a
+handle held across mutations always sees the current `(stmt, type, flag)`.
 
-Analogous to MLIR's `Operation` which knows its parent `Block` via `getBlock()`.
+Yielded by `instructions(block)` and usable as a key in `UseIndex`.
+
+Use the Symbol-keyed accessors (`inst[:stmt]`, `inst[:type]`, `inst[:flag]`)
+for reads and writes; `value_type(inst)`, `stmt(inst)`, `flag(inst)`,
+`block(inst)` are convenience aliases.
+
+Analogous to `Core.Compiler.Instruction` in `Compiler/src/ssair/ir.jl`,
+which is also a `(storage, key)` handle dispatching to parallel field
+vectors via `node[:stmt]` etc. — the difference being that the storage
+here is keyed by SSA index (preserved across structurization) rather
+than by dense position. Becomes stale on `delete!` of the underlying
+entry; identity (`==`, `hash`) is by `ssa_idx` only.
 """
 struct Instruction
     ssa_idx::Int
-    stmt::Any
-    type::Any
-    flag::UInt32  # IR_FLAG_* bitmask from Julia inference; 0 (IR_FLAG_NULL) if synthesized
     block::Any  # ::Block — untyped to avoid forward reference
 end
 
-# Convenience: construct without an explicit flag (defaults to IR_FLAG_NULL).
-# Matches the pre-`flag` constructor signature for callers that don't yet
-# carry per-stmt flags through.
-Instruction(ssa_idx::Int, @nospecialize(stmt), @nospecialize(type), @nospecialize(block)) =
-    Instruction(ssa_idx, stmt, type, UInt32(0), block)
-
 """Get the Julia type of the instruction result."""
-value_type(i::Instruction) = i.type
+value_type(i::Instruction) = (i.block::Block).body[i.ssa_idx].type
 
 """Get the underlying statement (Expr, ControlFlowOp, etc.)."""
-stmt(i::Instruction) = i.stmt
+stmt(i::Instruction) = (i.block::Block).body[i.ssa_idx].stmt
 
 """Get the per-statement IR flag bitmask (e.g. `IR_FLAG_EFFECT_FREE`).
 Carried through from `IRCode.stmts.flag` at structurization; 0 for stmts
 synthesized by the structurizer or by downstream passes."""
-flag(i::Instruction) = i.flag
+flag(i::Instruction) = (i.block::Block).body[i.ssa_idx].flag
 
 """Get the block containing this instruction."""
 block(i::Instruction) = i.block
@@ -99,10 +101,11 @@ Base.hash(i::Instruction, h::UInt) = hash(i.ssa_idx, h)
 
 function Base.show(io::IO, i::Instruction)
     print(io, "Instruction(%$(i.ssa_idx)")
-    if i.stmt isa ControlFlowOp
-        print(io, " = ", typeof(i.stmt))
-    elseif i.stmt isa Expr
-        print(io, " = ", i.stmt.head, "(...)")
+    s = stmt(i)
+    if s isa ControlFlowOp
+        print(io, " = ", typeof(s))
+    elseif s isa Expr
+        print(io, " = ", s.head, "(...)")
     end
     print(io, ")")
 end
@@ -394,9 +397,7 @@ Base.eltype(::Type{InstructionIterator}) = Instruction
 function Base.iterate(it::InstructionIterator, state::Int=1)
     m = it.block.body
     state > length(m.ssa_idxes) && return nothing
-    inst = Instruction(m.ssa_idxes[state], m.stmts[state], m.types[state],
-                       m.flags[state], it.block)
-    return inst, state + 1
+    return Instruction(m.ssa_idxes[state], it.block), state + 1
 end
 
 """

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -150,7 +150,7 @@ Read a field of the instruction's live entry in the containing block.
 function Base.getindex(inst::Instruction, fld::Symbol)
     fld === :ssa_idx && return inst.ssa_idx
     fld === :block   && return inst.block
-    m = (inst.block::Block).body
+    m = inst.block.body
     i = get(m.pos_by_idx, inst.ssa_idx, 0)
     i == 0 && throw(KeyError(inst.ssa_idx))
     fld === :stmt && return m.stmts[i]
@@ -167,7 +167,7 @@ end
 Write a single field of the instruction's live entry. Other fields are preserved.
 """
 function Base.setindex!(inst::Instruction, @nospecialize(val), fld::Symbol)
-    m = (inst.block::Block).body
+    m = inst.block.body
     i = get(m.pos_by_idx, inst.ssa_idx, 0)
     i == 0 && throw(KeyError(inst.ssa_idx))
     if fld === :stmt
@@ -1270,8 +1270,8 @@ handle pointing into the destination block.
 Analogous to MLIR's `Operation::moveBefore`.
 """
 function move_before!(inst::Instruction, target::Instruction)
-    src = inst.block::Block
-    dst = target.block::Block
+    src = inst.block
+    dst = target.block
     entry = src.body[inst.ssa_idx]
 
     delete!(src.body, inst.ssa_idx)
@@ -1297,8 +1297,8 @@ handle pointing into the destination block.
 Analogous to MLIR's `Operation::moveAfter`.
 """
 function move_after!(inst::Instruction, target::Instruction)
-    src = inst.block::Block
-    dst = target.block::Block
+    src = inst.block
+    dst = target.block
     entry = src.body[inst.ssa_idx]
 
     delete!(src.body, inst.ssa_idx)

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -89,10 +89,16 @@ function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(type);
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    pushfirst!(block.body.ssa_idxes, idx)
-    pushfirst!(block.body.stmts, stmt)
-    pushfirst!(block.body.types, type)
-    pushfirst!(block.body.flags, flag)
+    m = block.body
+    pushfirst!(m.ssa_idxes, idx)
+    pushfirst!(m.stmts, stmt)
+    pushfirst!(m.types, type)
+    pushfirst!(m.flags, flag)
+    # All existing positions shift up by one; new entry is at position 1.
+    for j in 2:length(m.ssa_idxes)
+        m.pos_by_idx[m.ssa_idxes[j]] = j
+    end
+    m.pos_by_idx[idx] = 1
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
@@ -161,8 +167,8 @@ Write a single field of the instruction's live entry. Other fields are preserved
 """
 function Base.setindex!(inst::Instruction, @nospecialize(val), fld::Symbol)
     m = (inst.block::Block).body
-    i = findfirst(==(inst.ssa_idx), m.ssa_idxes)
-    i === nothing && throw(KeyError(inst.ssa_idx))
+    i = get(m.pos_by_idx, inst.ssa_idx, 0)
+    i == 0 && throw(KeyError(inst.ssa_idx))
     if fld === :stmt
         m.stmts[i] = val
     elseif fld === :type
@@ -245,12 +251,16 @@ end
 
 function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, type,
                             flag::UInt32=UInt32(0))
-    pos = findfirst(==(before_idx), m.ssa_idxes)
-    pos === nothing && throw(KeyError(before_idx))
+    pos = get(m.pos_by_idx, before_idx, 0)
+    pos == 0 && throw(KeyError(before_idx))
     insert!(m.ssa_idxes, pos, new_idx)
     insert!(m.stmts, pos, stmt)
     insert!(m.types, pos, type)
     insert!(m.flags, pos, flag)
+    # Positions ≥ pos have shifted up by one; new entry sits at `pos`.
+    for j in pos:length(m.ssa_idxes)
+        m.pos_by_idx[m.ssa_idxes[j]] = j
+    end
 end
 
 """
@@ -269,12 +279,16 @@ end
 
 function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, type,
                            flag::UInt32=UInt32(0))
-    pos = findfirst(==(after_idx), m.ssa_idxes)
-    pos === nothing && throw(KeyError(after_idx))
+    pos = get(m.pos_by_idx, after_idx, 0)
+    pos == 0 && throw(KeyError(after_idx))
     insert!(m.ssa_idxes, pos + 1, new_idx)
     insert!(m.stmts, pos + 1, stmt)
     insert!(m.types, pos + 1, type)
     insert!(m.flags, pos + 1, flag)
+    # Positions ≥ pos+1 have shifted up by one; new entry sits at `pos+1`.
+    for j in pos+1:length(m.ssa_idxes)
+        m.pos_by_idx[m.ssa_idxes[j]] = j
+    end
 end
 
 """

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -76,7 +76,7 @@ function Base.push!(block::Block, @nospecialize(stmt), @nospecialize(type);
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, type, flag, block)
+    return Instruction(idx, block)
 end
 
 """
@@ -104,16 +104,15 @@ function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(type);
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, type, flag, block)
+    return Instruction(idx, block)
 end
 
 #=============================================================================
  Statement access — Symbol-keyed on Instruction, NamedTuple-keyed on Block
 
- Modeled on Core.Compiler.Instruction (`Compiler/src/ssair/ir.jl`). Reads and
- writes go through the live SSAMap entry, so `inst[:type] = T; inst[:type]`
- round-trips even though the snapshot fields on `Instruction` are stale —
- the upcoming handle migration removes that wart entirely.
+ Modeled on Core.Compiler.Instruction (`Compiler/src/ssair/ir.jl`): each
+ `Instruction` is a thin handle, and reads/writes resolve to the live
+ SSAMap entry on every access.
 
  When swapping a stmt for one with a different opcode, the old `flag` bits
  describe the OLD op and may be stale for the new one. Pass `flag=IR_FLAG_NULL`
@@ -129,8 +128,8 @@ Look up the instruction at the given SSA index, returning an `Instruction`
 handle. Throws `KeyError` if absent; pair with `haskey(block, ssa_idx)`.
 """
 function Base.getindex(block::Block, ssa_idx::Int)
-    entry = block.body[ssa_idx]
-    return Instruction(ssa_idx, entry.stmt, entry.type, entry.flag, block)
+    haskey(block.body, ssa_idx) || throw(KeyError(ssa_idx))
+    return Instruction(ssa_idx, block)
 end
 
 """
@@ -246,7 +245,7 @@ function insert_before!(block::Block, ref::Instruction, @nospecialize(stmt), @no
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     insert_before_idx!(block.body, ref.ssa_idx, idx, stmt, type, flag)
-    return Instruction(idx, stmt, type, flag, block)
+    return Instruction(idx, block)
 end
 
 function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, type,
@@ -274,7 +273,7 @@ function insert_after!(block::Block, ref::Instruction, @nospecialize(stmt), @nos
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     insert_after_idx!(block.body, ref.ssa_idx, idx, stmt, type, flag)
-    return Instruction(idx, stmt, type, flag, block)
+    return Instruction(idx, block)
 end
 
 function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, type,
@@ -307,7 +306,7 @@ function insert_before!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospe
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, type, flag, block)
+    return Instruction(idx, block)
 end
 
 """
@@ -326,7 +325,7 @@ function insert_after!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospec
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, type, flag, block)
+    return Instruction(idx, block)
 end
 
 
@@ -1257,59 +1256,55 @@ end
 =============================================================================#
 
 """
-    move_before!(inst::Instruction, target::Instruction)
+    move_before!(inst::Instruction, target::Instruction) -> Instruction
 
 Move `inst` from its current block to just before `target` in `target`'s block.
-The instruction retains its SSA index. Sub-block parents are updated if the
-instruction is a `ControlFlowOp`.
+The instruction retains its SSA index, statement, type, and flags. Sub-block
+parents are updated if the instruction is a `ControlFlowOp`. Returns a fresh
+handle pointing into the destination block.
 
 Analogous to MLIR's `Operation::moveBefore`.
 """
 function move_before!(inst::Instruction, target::Instruction)
     src = inst.block::Block
     dst = target.block::Block
-    s = inst[:stmt]; t = inst[:type]
+    entry = src.body[inst.ssa_idx]
 
-    # Remove from source
     delete!(src.body, inst.ssa_idx)
+    insert_before_idx!(dst.body, target.ssa_idx, inst.ssa_idx,
+                       entry.stmt, entry.type, entry.flag)
 
-    # Insert before target in destination
-    insert_before_idx!(dst.body, target.ssa_idx, inst.ssa_idx, s, t)
-
-    # Update sub-block parents
-    if s isa ControlFlowOp
-        for b in blocks(s)
+    if entry.stmt isa ControlFlowOp
+        for b in blocks(entry.stmt)
             b.parent = dst
         end
     end
-    return inst
+    return Instruction(inst.ssa_idx, dst)
 end
 
 """
-    move_after!(inst::Instruction, target::Instruction)
+    move_after!(inst::Instruction, target::Instruction) -> Instruction
 
 Move `inst` from its current block to just after `target` in `target`'s block.
-The instruction retains its SSA index. Sub-block parents are updated if the
-instruction is a `ControlFlowOp`.
+The instruction retains its SSA index, statement, type, and flags. Sub-block
+parents are updated if the instruction is a `ControlFlowOp`. Returns a fresh
+handle pointing into the destination block.
 
 Analogous to MLIR's `Operation::moveAfter`.
 """
 function move_after!(inst::Instruction, target::Instruction)
     src = inst.block::Block
     dst = target.block::Block
-    s = inst[:stmt]; t = inst[:type]
+    entry = src.body[inst.ssa_idx]
 
-    # Remove from source
     delete!(src.body, inst.ssa_idx)
+    insert_after_idx!(dst.body, target.ssa_idx, inst.ssa_idx,
+                      entry.stmt, entry.type, entry.flag)
 
-    # Insert after target in destination
-    insert_after_idx!(dst.body, target.ssa_idx, inst.ssa_idx, s, t)
-
-    # Update sub-block parents
-    if s isa ControlFlowOp
-        for b in blocks(s)
+    if entry.stmt isa ControlFlowOp
+        for b in blocks(entry.stmt)
             b.parent = dst
         end
     end
-    return inst
+    return Instruction(inst.ssa_idx, dst)
 end

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -150,10 +150,12 @@ Read a field of the instruction's live entry in the containing block.
 function Base.getindex(inst::Instruction, fld::Symbol)
     fld === :ssa_idx && return inst.ssa_idx
     fld === :block   && return inst.block
-    entry = (inst.block::Block).body[inst.ssa_idx]
-    fld === :stmt && return entry.stmt
-    fld === :type && return entry.type
-    fld === :flag && return entry.flag
+    m = (inst.block::Block).body
+    i = get(m.pos_by_idx, inst.ssa_idx, 0)
+    i == 0 && throw(KeyError(inst.ssa_idx))
+    fld === :stmt && return m.stmts[i]
+    fld === :type && return m.types[i]
+    fld === :flag && return m.flags[i]
     throw(ArgumentError("Instruction has no field $fld; expected one of (:stmt, :type, :flag, :ssa_idx, :block)"))
 end
 

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -956,8 +956,9 @@ function _walk_pre!(f, block::Block)
     for inst in instructions(block)
         result = f(inst, block)
         result === :interrupt && return :interrupt
-        if stmt(inst) isa ControlFlowOp && result !== :skip
-            for b in blocks(stmt(inst))
+        s = inst[:stmt]
+        if s isa ControlFlowOp && result !== :skip
+            for b in blocks(s)
                 _walk_pre!(f, b) === :interrupt && return :interrupt
             end
         end
@@ -967,8 +968,9 @@ end
 
 function _walk_post!(f, block::Block)
     for inst in instructions(block)
-        if stmt(inst) isa ControlFlowOp
-            for b in blocks(stmt(inst))
+        s = inst[:stmt]
+        if s isa ControlFlowOp
+            for b in blocks(s)
                 _walk_post!(f, b) === :interrupt && return :interrupt
             end
         end

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -1,7 +1,9 @@
 # Utilities for structured IR
 #
 # Block mutation: parent, root, push!, pushfirst!, insert_before!, insert_after!,
-#                 delete!, update_type!, new_block_arg!
+#                 delete!, new_block_arg!
+# Statement mutation: block[ssa_idx] = (; stmt, type, flag)  — partial NamedTuple
+#                     inst[:stmt] = …, inst[:type] = …, inst[:flag] = …
 # Block traversal: eachblock, findblock
 # Use tracking: uses(), replace_uses!
 # Loop carries: carries()
@@ -16,7 +18,7 @@
 
 public root, parent, walk_uses!, IndexedUseRef
 export insert_before!, insert_after!, eachblock, findblock,
-       update_type!, new_block_arg!,
+       new_block_arg!,
        resolve_call, iscall, callee, callargs,
        reachable_terminators, walk, after_arg,
        def, defs,
@@ -48,60 +50,129 @@ function Base.delete!(block::Block, inst::Instruction)
     return block
 end
 
+"""Delete an instruction from a block by SSA index. Throws `KeyError` if absent;
+pair with `haskey(block, ssa_idx)` for the idempotent erase pattern."""
+Base.delete!(block::Block, ssa_idx::Int) = (delete!(block.body, ssa_idx); block)
+
+"""Whether `block` contains an instruction with the given SSA index."""
+Base.haskey(block::Block, ssa_idx::Int) = haskey(block.body, ssa_idx)
+
 """
-    push!(block::Block, stmt, typ; flag=0) -> Instruction
+    push!(block::Block, stmt, type; flag=0) -> Instruction
 
 Append a new instruction to the block, auto-allocating an SSA index.
 Requires `block.parent` to be set (see `_set_parent!`). Optional `flag` is
 the per-statement `IR_FLAG_*` bitmask (defaults to 0 / `IR_FLAG_NULL`);
-keyword-only to avoid ambiguity with the explicit-idx `push!(block, idx, stmt, typ)`.
+keyword-only to avoid ambiguity with the explicit-idx `push!(block, idx, stmt, type)`.
 """
-function Base.push!(block::Block, @nospecialize(stmt), @nospecialize(typ);
+function Base.push!(block::Block, @nospecialize(stmt), @nospecialize(type);
                     flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    push!(block.body, (idx, stmt, typ, flag))
+    push!(block.body, (idx, stmt, type, flag))
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, flag, block)
+    return Instruction(idx, stmt, type, flag, block)
 end
 
 """
-    pushfirst!(block::Block, stmt, typ; flag=0) -> Instruction
+    pushfirst!(block::Block, stmt, type; flag=0) -> Instruction
 
 Prepend a new instruction at the beginning of the block, auto-allocating an SSA index.
 """
-function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(typ);
+function Base.pushfirst!(block::Block, @nospecialize(stmt), @nospecialize(type);
                          flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
     pushfirst!(block.body.ssa_idxes, idx)
     pushfirst!(block.body.stmts, stmt)
-    pushfirst!(block.body.types, typ)
+    pushfirst!(block.body.types, type)
     pushfirst!(block.body.flags, flag)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, flag, block)
+    return Instruction(idx, stmt, type, flag, block)
+end
+
+#=============================================================================
+ Statement access — Symbol-keyed on Instruction, NamedTuple-keyed on Block
+
+ Modeled on Core.Compiler.Instruction (`Compiler/src/ssair/ir.jl`). Reads and
+ writes go through the live SSAMap entry, so `inst[:type] = T; inst[:type]`
+ round-trips even though the snapshot fields on `Instruction` are stale —
+ the upcoming handle migration removes that wart entirely.
+
+ When swapping a stmt for one with a different opcode, the old `flag` bits
+ describe the OLD op and may be stale for the new one. Pass `flag=IR_FLAG_NULL`
+ to clear, mirroring LLVM's "fresh instruction, then opt-in `copyIRFlags`"
+ pattern (see `Instruction.h:copyIRFlags`). Same-opcode rewrites (only
+ operands change) keep the flag.
+=============================================================================#
+
+"""
+    block[ssa_idx] -> Instruction
+
+Look up the instruction at the given SSA index, returning an `Instruction`
+handle. Throws `KeyError` if absent; pair with `haskey(block, ssa_idx)`.
+"""
+function Base.getindex(block::Block, ssa_idx::Int)
+    entry = block.body[ssa_idx]
+    return Instruction(ssa_idx, entry.stmt, entry.type, entry.flag, block)
 end
 
 """
-    update_type!(block::Block, inst::Instruction, new_type)
+    block[ssa_idx] = (; stmt=…, type=…, flag=…)
 
-Update the type annotation for an existing instruction.
+Update one or more fields of the entry at `ssa_idx`. Any subset of
+`(:stmt, :type, :flag)` is accepted; fields not mentioned are preserved.
 """
-function update_type!(block::Block, inst::Instruction, @nospecialize(new_type))
-    pos = findfirst(==(inst.ssa_idx), block.body.ssa_idxes)
-    pos === nothing && throw(KeyError(inst.ssa_idx))
-    block.body.types[pos] = new_type
-    return nothing
+Base.setindex!(block::Block, entry::NamedTuple, ssa_idx::Int) =
+    (block.body[ssa_idx] = entry; block)
+
+"""
+    inst[:stmt] | inst[:type] | inst[:flag]
+    inst[:ssa_idx] | inst[:block]
+
+Read a field of the instruction's live entry in the containing block.
+"""
+function Base.getindex(inst::Instruction, fld::Symbol)
+    fld === :ssa_idx && return inst.ssa_idx
+    fld === :block   && return inst.block
+    entry = (inst.block::Block).body[inst.ssa_idx]
+    fld === :stmt && return entry.stmt
+    fld === :type && return entry.type
+    fld === :flag && return entry.flag
+    throw(ArgumentError("Instruction has no field $fld; expected one of (:stmt, :type, :flag, :ssa_idx, :block)"))
+end
+
+"""
+    inst[:stmt] = newstmt
+    inst[:type] = T
+    inst[:flag] = f
+
+Write a single field of the instruction's live entry. Other fields are preserved.
+"""
+function Base.setindex!(inst::Instruction, @nospecialize(val), fld::Symbol)
+    m = (inst.block::Block).body
+    i = findfirst(==(inst.ssa_idx), m.ssa_idxes)
+    i === nothing && throw(KeyError(inst.ssa_idx))
+    if fld === :stmt
+        m.stmts[i] = val
+    elseif fld === :type
+        m.types[i] = val
+    elseif fld === :flag
+        m.flags[i] = val
+    else
+        throw(ArgumentError("Instruction setindex! field must be one of (:stmt, :type, :flag), got :$fld"))
+    end
+    return val
 end
 
 """
@@ -118,11 +189,11 @@ Returns `nothing` only for an `SSAValue` or `Argument` whose type cannot be foun
 function value_type(block::Block, @nospecialize(val))
     if val isa SSAValue
         entry = get(block.body, val.id, nothing)
-        entry !== nothing && return entry.typ
+        entry !== nothing && return entry.type
         p = block.parent
         while p isa Block
             entry = get(p.body, val.id, nothing)
-            entry !== nothing && return entry.typ
+            entry !== nothing && return entry.type
             p = p.parent
         end
         return nothing
@@ -146,102 +217,102 @@ function value_type(block::Block, @nospecialize(val))
 end
 
 """
-    new_block_arg!(block::Block, typ) -> BlockArgument
+    new_block_arg!(block::Block, type) -> BlockArgument
 
 Add a new BlockArgument to a block, allocating a fresh ID from the root StructuredIRCode.
 """
-function new_block_arg!(block::Block, @nospecialize(typ))
+function new_block_arg!(block::Block, @nospecialize(type))
     sci = root(block)
     sci.max_arg_idx += 1
-    arg = BlockArgument(sci.max_arg_idx, typ)
+    arg = BlockArgument(sci.max_arg_idx, type)
     push!(block.args, arg)
     return arg
 end
 
 """
-    insert_before!(block::Block, ref::Instruction, stmt, typ; flag=0) -> Instruction
+    insert_before!(block::Block, ref::Instruction, stmt, type; flag=0) -> Instruction
 
 Insert a new instruction before `ref`, auto-allocating an SSA index.
 """
-function insert_before!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ);
+function insert_before!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(type);
                         flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_before_idx!(block.body, ref.ssa_idx, idx, stmt, typ, flag)
-    return Instruction(idx, stmt, typ, flag, block)
+    insert_before_idx!(block.body, ref.ssa_idx, idx, stmt, type, flag)
+    return Instruction(idx, stmt, type, flag, block)
 end
 
-function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, typ,
+function insert_before_idx!(m::SSAMap, before_idx::Int, new_idx::Int, stmt, type,
                             flag::UInt32=UInt32(0))
     pos = findfirst(==(before_idx), m.ssa_idxes)
     pos === nothing && throw(KeyError(before_idx))
     insert!(m.ssa_idxes, pos, new_idx)
     insert!(m.stmts, pos, stmt)
-    insert!(m.types, pos, typ)
+    insert!(m.types, pos, type)
     insert!(m.flags, pos, flag)
 end
 
 """
-    insert_after!(block::Block, ref::Instruction, stmt, typ; flag=0) -> Instruction
+    insert_after!(block::Block, ref::Instruction, stmt, type; flag=0) -> Instruction
 
 Insert a new instruction after `ref`, auto-allocating an SSA index.
 """
-function insert_after!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(typ);
+function insert_after!(block::Block, ref::Instruction, @nospecialize(stmt), @nospecialize(type);
                        flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_after_idx!(block.body, ref.ssa_idx, idx, stmt, typ, flag)
-    return Instruction(idx, stmt, typ, flag, block)
+    insert_after_idx!(block.body, ref.ssa_idx, idx, stmt, type, flag)
+    return Instruction(idx, stmt, type, flag, block)
 end
 
-function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, typ,
+function insert_after_idx!(m::SSAMap, after_idx::Int, new_idx::Int, stmt, type,
                            flag::UInt32=UInt32(0))
     pos = findfirst(==(after_idx), m.ssa_idxes)
     pos === nothing && throw(KeyError(after_idx))
     insert!(m.ssa_idxes, pos + 1, new_idx)
     insert!(m.stmts, pos + 1, stmt)
-    insert!(m.types, pos + 1, typ)
+    insert!(m.types, pos + 1, type)
     insert!(m.flags, pos + 1, flag)
 end
 
 """
-    insert_before!(block::Block, ref::SSAValue, stmt, typ; flag=0) -> Instruction
+    insert_before!(block::Block, ref::SSAValue, stmt, type; flag=0) -> Instruction
 
 Insert a new instruction before the instruction at SSA index `ref.id`.
 """
-function insert_before!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(typ);
+function insert_before!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(type);
                         flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_before_idx!(block.body, ref.id, idx, stmt, typ, flag)
+    insert_before_idx!(block.body, ref.id, idx, stmt, type, flag)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, flag, block)
+    return Instruction(idx, stmt, type, flag, block)
 end
 
 """
-    insert_after!(block::Block, ref::SSAValue, stmt, typ; flag=0) -> Instruction
+    insert_after!(block::Block, ref::SSAValue, stmt, type; flag=0) -> Instruction
 
 Insert a new instruction after the instruction at SSA index `ref.id`.
 """
-function insert_after!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(typ);
+function insert_after!(block::Block, ref::SSAValue, @nospecialize(stmt), @nospecialize(type);
                        flag::UInt32=UInt32(0))
     sci = root(block)
     sci.max_ssa_idx += 1
     idx = sci.max_ssa_idx
-    insert_after_idx!(block.body, ref.id, idx, stmt, typ, flag)
+    insert_after_idx!(block.body, ref.id, idx, stmt, type, flag)
     if stmt isa ControlFlowOp
         for b in blocks(stmt)
             b.parent = block
         end
     end
-    return Instruction(idx, stmt, typ, flag, block)
+    return Instruction(idx, stmt, type, flag, block)
 end
 
 
@@ -519,7 +590,7 @@ function users(block::Block, @nospecialize(val))
     for b in eachblock(block)
         for inst in instructions(b)
             inst.ssa_idx in seen && continue
-            _references(inst.stmt, target) || continue
+            _references(inst[:stmt], target) || continue
             push!(seen, inst.ssa_idx)
             push!(result, inst)
         end
@@ -928,7 +999,7 @@ function resolve_call(block::Block, @nospecialize(stmt))
     return (resolved, operands)
 end
 
-resolve_call(block::Block, inst::Instruction) = resolve_call(block, inst.stmt)
+resolve_call(block::Block, inst::Instruction) = resolve_call(block, inst[:stmt])
 
 """
     resolve_callee(block::Block, ref) -> resolved_func or nothing
@@ -969,7 +1040,7 @@ iscall(@nospecialize(stmt)) = stmt isa Expr && (stmt.head === :call || stmt.head
 
 Convenience overload: checks the underlying statement.
 """
-iscall(inst::Instruction) = iscall(inst.stmt)
+iscall(inst::Instruction) = iscall(inst[:stmt])
 
 """
     callee(stmt::Expr) -> Any
@@ -992,7 +1063,7 @@ end
 
 Convenience overload: extracts callee from the underlying statement.
 """
-callee(inst::Instruction) = callee(inst.stmt::Expr)
+callee(inst::Instruction) = callee(inst[:stmt]::Expr)
 
 """
     callargs(stmt::Expr) -> SubArray
@@ -1014,7 +1085,7 @@ end
 
 Convenience overload: extracts call arguments from the underlying statement.
 """
-callargs(inst::Instruction) = callargs(inst.stmt::Expr)
+callargs(inst::Instruction) = callargs(inst[:stmt]::Expr)
 
 
 #=============================================================================
@@ -1031,7 +1102,7 @@ Returns `Any[]` for unknown statement types.
 
 Extend via `operands(::Block, s::MyType)` for domain-specific IR nodes.
 """
-operands(block::Block, inst::Instruction) = operands(block, inst.stmt)
+operands(block::Block, inst::Instruction) = operands(block, inst[:stmt])
 
 operands(::Block, s::PiNode) = Any[s.val]
 operands(::Block, s::ControlFlowOp) = operands(s)
@@ -1183,16 +1254,17 @@ Analogous to MLIR's `Operation::moveBefore`.
 function move_before!(inst::Instruction, target::Instruction)
     src = inst.block::Block
     dst = target.block::Block
+    s = inst[:stmt]; t = inst[:type]
 
     # Remove from source
     delete!(src.body, inst.ssa_idx)
 
     # Insert before target in destination
-    insert_before_idx!(dst.body, target.ssa_idx, inst.ssa_idx, inst.stmt, inst.typ)
+    insert_before_idx!(dst.body, target.ssa_idx, inst.ssa_idx, s, t)
 
     # Update sub-block parents
-    if inst.stmt isa ControlFlowOp
-        for b in blocks(inst.stmt)
+    if s isa ControlFlowOp
+        for b in blocks(s)
             b.parent = dst
         end
     end
@@ -1211,16 +1283,17 @@ Analogous to MLIR's `Operation::moveAfter`.
 function move_after!(inst::Instruction, target::Instruction)
     src = inst.block::Block
     dst = target.block::Block
+    s = inst[:stmt]; t = inst[:type]
 
     # Remove from source
     delete!(src.body, inst.ssa_idx)
 
     # Insert after target in destination
-    insert_after_idx!(dst.body, target.ssa_idx, inst.ssa_idx, inst.stmt, inst.typ)
+    insert_after_idx!(dst.body, target.ssa_idx, inst.ssa_idx, s, t)
 
     # Update sub-block parents
-    if inst.stmt isa ControlFlowOp
-        for b in blocks(inst.stmt)
+    if s isa ControlFlowOp
+        for b in blocks(s)
             b.parent = dst
         end
     end

--- a/src/ir/validation.jl
+++ b/src/ir/validation.jl
@@ -106,7 +106,7 @@ function validate_terminators!(errors::Vector{String}, sci::StructuredIRCode, bl
     for (idx, entry) in block.body
         stmt = entry.stmt
         if stmt isa IfOp
-            validate_if_terminators!(errors, sci, stmt, idx, entry.typ)
+            validate_if_terminators!(errors, sci, stmt, idx, entry.type)
         elseif stmt isa ForOp
             validate_for_terminators!(errors, sci, stmt, idx)
         elseif stmt isa WhileOp
@@ -460,7 +460,7 @@ resolve_type(sci::StructuredIRCode, value) = typeof(value)
 function resolve_type(sci::StructuredIRCode, value::SSAValue)
     for block in eachblock(sci)
         entry = get(block.body, value.id, nothing)
-        entry !== nothing && return entry.typ
+        entry !== nothing && return entry.type
     end
     return nothing
 end

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -285,7 +285,7 @@ end
 
 function merge_block_into!(dst::Block, src::Block)
     for (idx, entry) in src.body
-        push!(dst.body, (idx, entry.stmt, entry.typ, entry.flag))
+        push!(dst.body, (idx, entry.stmt, entry.type, entry.flag))
     end
     if src.terminator !== nothing && dst.terminator === nothing
         dst.terminator = src.terminator

--- a/src/structurize/promote.jl
+++ b/src/structurize/promote.jl
@@ -31,7 +31,7 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
             result, removed, redirect = try_promote_for_from_loop(stmt, idx, block, new_body, ctx)
             if result isa ForOp
                 for_promotions[idx] = (removed, result, redirect)
-                carry_types = Any[t for (i, t) in enumerate(entry.typ.parameters) if i ∉ removed]
+                carry_types = Any[t for (i, t) in enumerate(entry.type.parameters) if i ∉ removed]
                 push!(new_body, (idx, result, Tuple{carry_types...}, entry.flag))
             else
                 # Fall back to existing path: LoopOp → WhileOp → ForOp
@@ -40,13 +40,13 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                     result2, iv_pos = try_promote_for(promoted, idx, block, new_body, ctx)
                     if result2 isa ForOp && iv_pos > 0
                         for_promotions[idx] = ([iv_pos], result2, Dict{Int,Int}())
-                        carry_types = Any[t for (i, t) in enumerate(entry.typ.parameters) if i != iv_pos]
+                        carry_types = Any[t for (i, t) in enumerate(entry.type.parameters) if i != iv_pos]
                         push!(new_body, (idx, result2, Tuple{carry_types...}, entry.flag))
                     else
-                        push!(new_body, (idx, result2, entry.typ, entry.flag))
+                        push!(new_body, (idx, result2, entry.type, entry.flag))
                     end
                 else
-                    push!(new_body, (idx, stmt, entry.typ, entry.flag))
+                    push!(new_body, (idx, stmt, entry.type, entry.flag))
                 end
             end
         elseif stmt isa Expr && stmt.head === :call && stmt.args[1] === Core.getfield &&
@@ -61,22 +61,22 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                     # Duplicate carry → redirect to surviving carry's adjusted index
                     adjusted = target_pos - count(p -> p < target_pos, removed)
                     new_gf = Expr(:call, Core.getfield, SSAValue(loop_ssa), adjusted)
-                    push!(new_body, (idx, new_gf, entry.typ, entry.flag))
+                    push!(new_body, (idx, new_gf, entry.type, entry.flag))
                 else
-                    push!(new_body, (idx, for_op.upper, entry.typ, entry.flag))
+                    push!(new_body, (idx, for_op.upper, entry.type, entry.flag))
                 end
             else
                 adjusted = field_idx - count(p -> p < field_idx, removed)
                 new_gf = Expr(:call, Core.getfield, SSAValue(loop_ssa), adjusted)
-                push!(new_body, (idx, new_gf, entry.typ, entry.flag))
+                push!(new_body, (idx, new_gf, entry.type, entry.flag))
             end
         elseif stmt isa ControlFlowOp
             for b in blocks(stmt)
                 promote_loops!(b, ctx)
             end
-            push!(new_body, (idx, stmt, entry.typ, entry.flag))
+            push!(new_body, (idx, stmt, entry.type, entry.flag))
         else
-            push!(new_body, (idx, stmt, entry.typ, entry.flag))
+            push!(new_body, (idx, stmt, entry.type, entry.flag))
         end
     end
     block.body = new_body
@@ -192,13 +192,13 @@ function simplify_loop_exit(body::Block)
     # Build merged IfOp: inner condition true → done → break, false → continue
     merged_then = Block()
     for (sidx, sentry) in done_body_region.body
-        push!(merged_then.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(merged_then.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
     merged_then.terminator = BreakOp(break_values)
 
     merged_else = Block()
     for (sidx, sentry) in cont_body_region.body
-        push!(merged_else.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(merged_else.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
     merged_else.terminator = ContinueOp(cont_values)
 
@@ -211,7 +211,7 @@ function simplify_loop_exit(body::Block)
     end
     for (sidx, sentry) in body.body
         sidx == inner_result.id && break
-        push!(result.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(result.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
     push!(result.body, (outer_idx, merged_if, Tuple{}))
     return result
@@ -427,11 +427,11 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
     last_idx = body.body.ssa_idxes[end]
     for (sidx, sentry) in body.body
         sidx == last_idx && break
-        push!(for_body.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(for_body.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
     for (sidx, sentry) in cont_region.body
         step_ssa !== nothing && sidx == step_ssa && continue  # skip IV increment
-        push!(for_body.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(for_body.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
 
     # ContinueOp with non-IV, non-shadow values
@@ -506,7 +506,7 @@ function try_promote_while(loop::LoopOp, ctx::StructurizeCtx)
     before = Block()
     for (i, (sidx, sentry)) in enumerate(body.body)
         sidx == last_idx && break
-        push!(before.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(before.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
     for arg in body.args
         push!(before.args, arg)
@@ -525,7 +525,7 @@ function try_promote_while(loop::LoopOp, ctx::StructurizeCtx)
         arg_remap[arg.id] = after_arg
     end
     for (sidx, sentry) in stay_region.body
-        push!(after.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(after.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
     after.terminator = YieldOp(copy(continue_op.values))
 
@@ -667,7 +667,7 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
         if carried_val isa SSAValue && sidx == carried_val.id
             continue
         end
-        push!(for_body.body, (sidx, sentry.stmt, sentry.typ, sentry.flag))
+        push!(for_body.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
 
     # ContinueOp with non-IV carried values
@@ -703,7 +703,7 @@ function remap_block_args!(block::Block, remap::Dict{Int, BlockArgument})
     new_body = SSAMap()
     for (idx, entry) in block.body
         new_stmt = remap_value(entry.stmt, remap)
-        push!(new_body, (idx, new_stmt, entry.typ, entry.flag))
+        push!(new_body, (idx, new_stmt, entry.type, entry.flag))
     end
     block.body = new_body
     if block.terminator !== nothing

--- a/src/structurize/substitutions.jl
+++ b/src/structurize/substitutions.jl
@@ -66,10 +66,10 @@ function apply_substitutions!(block::Block, subs::Substitutions, ctx)
     for (idx, entry) in block.body
         if entry.stmt isa ControlFlowOp
             apply_substitutions!(entry.stmt, subs, ctx)
-            push!(new_body, (idx, entry.stmt, entry.typ, entry.flag))
+            push!(new_body, (idx, entry.stmt, entry.type, entry.flag))
         else
             new_expr = substitute_ssa(entry.stmt, subs)
-            push!(new_body, (idx, new_expr, entry.typ, entry.flag))
+            push!(new_body, (idx, new_expr, entry.type, entry.flag))
         end
     end
     block.body = new_body

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -402,7 +402,7 @@ function tail_duplicate_branch!(b::Block, dest::Int,
     ctx.ssa_remap = saved_remap
 
     for (idx, entry) in sub_block.body
-        push!(b.body, (idx, entry.stmt, entry.typ, entry.flag))
+        push!(b.body, (idx, entry.stmt, entry.type, entry.flag))
     end
     b.terminator = sub_block.terminator
     return b

--- a/src/unstructurize.jl
+++ b/src/unstructurize.jl
@@ -156,7 +156,7 @@ Lower a structured IR Block's body into flat BBs. Returns the last BB used
 """
 function lower_block_body!(ctx::UnstructurizeCtx, bb::Int, block::Block)
     for (idx, entry) in block.body
-        stmt, typ = entry.stmt, entry.typ
+        stmt, typ = entry.stmt, entry.type
         if stmt isa IfOp
             bb = lower_ifop!(ctx, bb, idx, stmt, typ)
         elseif stmt isa ForOp

--- a/test/debuginfo.jl
+++ b/test/debuginfo.jl
@@ -32,7 +32,7 @@
         sci, _ = code_structured(g, Tuple{Int}) |> only
         # Find the IfOp instruction
         for inst in instructions(sci.entry)
-            if stmt(inst) isa IfOp
+            if inst[:stmt] isa IfOp
                 locs = source_location(sci, inst)
                 # Should have inherited debug info from the branch condition
                 @test !isempty(locs)
@@ -171,7 +171,7 @@
         # Find a loop op and check it has debug info
         found_loop = false
         for inst in instructions(sci.entry)
-            s = stmt(inst)
+            s = inst[:stmt]
             if s isa LoopOp || s isa ForOp || s isa WhileOp
                 locs = source_location(sci, inst)
                 if !isempty(locs)

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -14,7 +14,7 @@
     @test !isempty(insts)
     @test all(i -> i isa Instruction, insts)
 
-    # Each Instruction bundles ssa_idx, stmt, typ, flag
+    # Each Instruction bundles ssa_idx, stmt, type, flag
     inst = first(insts)
     @test value_type(inst) isa Type
     @test SSAValue(inst) isa SSAValue
@@ -168,7 +168,7 @@ end  # types & accessors
     @test bp < rp < ap
 end
 
-@testset "pushfirst!(block, stmt, typ)" begin
+@testset "pushfirst!(block, stmt, type)" begin
     sci, _ = code_structured(Tuple{Int}) do x::Int
         x + 1
     end |> only
@@ -250,21 +250,51 @@ end
     @test !(42 ∈ sci.entry)
 end
 
-@testset "update_type!(block, inst, new_type)" begin
+@testset "inst[:type] = T (Symbol-keyed setindex!)" begin
     sci, _ = code_structured(Tuple{Int}) do x::Int
         x + 1
     end |> only
 
     inst = first(instructions(sci.entry))
-    old_type = value_type(inst)
-    update_type!(sci.entry, inst, Float64)
+    inst[:type] = Float64
 
-    # Re-read from block to verify
-    updated = first(instructions(sci.entry))
-    @test value_type(updated) == Float64
+    # Live read via Symbol; the mutation round-trips.
+    @test inst[:type] == Float64
+    # Re-fetching from the block agrees.
+    @test first(instructions(sci.entry))[:type] == Float64
 end
 
-@testset "new_block_arg!(block, typ)" begin
+@testset "block[ssa_idx] = (...) — partial NamedTuple updates" begin
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+    inst = first(instructions(sci.entry))
+    idx = inst.ssa_idx
+
+    # block[idx] returns the Instruction handle.
+    @test sci.entry[idx] isa Instruction
+    @test sci.entry[idx].ssa_idx == idx
+
+    # Single-field write via block: only :type changes; stmt and flag preserved.
+    orig_stmt = inst[:stmt]
+    orig_flag = inst[:flag]
+    sci.entry[idx] = (type=Float32,)
+    @test sci.entry[idx][:type] == Float32
+    @test sci.entry[idx][:stmt] === orig_stmt
+    @test sci.entry[idx][:flag] === orig_flag
+
+    # Replace stmt; flag preservation is the caller's choice (no implicit
+    # reset). Pass IR_FLAG_NULL explicitly for the LLVM-style safe default.
+    new_stmt = Expr(:call, +, Core.Argument(2), 2)
+    sci.entry[idx] = (stmt=new_stmt, flag=UInt32(0))
+    @test sci.entry[idx][:stmt] === new_stmt
+    @test sci.entry[idx][:flag] == UInt32(0)
+
+    # Symbol-keyed setindex! errors on unknown fields.
+    @test_throws ArgumentError (inst[:bogus] = 1)
+end
+
+@testset "new_block_arg!(block, type)" begin
     sci, _ = code_structured(Tuple{Int}) do n::Int
         i = 0
         while i < n
@@ -1089,8 +1119,10 @@ end  # loop carries
     @test resolve_call(block, 42) === nothing
     @test resolve_call(block, Expr(:new, :Foo)) === nothing
 
-    # Instruction overload
-    inst = Instruction(1, expr_call, Int, UInt32(0), Block())
+    # Instruction overload — synthetic Instruction pointing into a fresh block
+    fake_block = Block()
+    push!(fake_block.body, (1, expr_call, Int, UInt32(0)))
+    inst = fake_block[1]
     result3 = resolve_call(block, inst)
     @test result3 !== nothing
     @test first(result3) === Base.:+
@@ -1155,8 +1187,10 @@ end
     @test !iscall(42)
     @test !iscall(Expr(:new, :Foo))
 
-    # Instruction overloads
-    inst = Instruction(1, expr_call, Int, UInt32(0), Block())
+    # Instruction overloads — synthetic Instruction pointing into a fresh block
+    fake_block = Block()
+    push!(fake_block.body, (1, expr_call, Int, UInt32(0)))
+    inst = fake_block[1]
     @test iscall(inst)
     @test callee(inst) == GlobalRef(Base, :+)
     @test length(callargs(inst)) == 2

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -17,9 +17,9 @@
     # Each Instruction is a handle exposing ssa_idx, stmt, type, flag
     inst = first(insts)
     @test value_type(inst) isa Type
+    @test value_type(inst) === inst[:type]
     @test SSAValue(inst) isa SSAValue
-    @test flag(inst) isa UInt32
-    @test inst[:flag] === flag(inst)
+    @test inst[:flag] isa UInt32
 end
 
 @testset "per-stmt flag carried through from IRCode" begin
@@ -32,9 +32,9 @@ end
     end |> only
     found_pure = false
     for inst in instructions(sci.entry)
-        s = stmt(inst)
+        s = inst[:stmt]
         if s isa Expr && s.head === :call
-            (flag(inst) & Core.Compiler.IR_FLAG_EFFECT_FREE) != 0 && (found_pure = true; break)
+            (inst[:flag] & Core.Compiler.IR_FLAG_EFFECT_FREE) != 0 && (found_pure = true; break)
         end
     end
     @test found_pure
@@ -55,7 +55,7 @@ end
     @test inst[:type] === Float64
 
     inst[:flag] = UInt32(0)
-    @test flag(inst) === UInt32(0)
+    @test inst[:flag] === UInt32(0)
 
     # A second handle to the same SSA index sees the same live entry.
     other = sci.entry[inst.ssa_idx]
@@ -78,8 +78,8 @@ end
 
     # ForOp body has arguments (IV + carries)
     for inst in instructions(sci.entry)
-        if stmt(inst) isa ForOp
-            body_args = arguments(stmt(inst).body)
+        if inst[:stmt] isa ForOp
+            body_args = arguments(inst[:stmt].body)
             @test !isempty(body_args)
             @test all(a -> a isa BlockArgument, body_args)
             break
@@ -139,8 +139,8 @@ end
     end |> only
 
     for inst in instructions(sci.entry)
-        if stmt(inst) isa IfOp
-            bs = blocks(stmt(inst))
+        if inst[:stmt] isa IfOp
+            bs = blocks(inst[:stmt])
             @test length(bs) == 2
             @test all(b -> b isa Block, bs)
             break
@@ -246,7 +246,7 @@ end
     # Find a loop and check its body
     loop_op = nothing
     for inst in instructions(sci.entry)
-        s = stmt(inst)
+        s = inst[:stmt]
         if s isa ForOp || s isa WhileOp || s isa LoopOp
             loop_op = s
             break
@@ -328,7 +328,7 @@ end
 
     # Find a loop body block with args
     for inst in instructions(sci.entry)
-        op = stmt(inst)
+        op = inst[:stmt]
         op isa ForOp || continue
 
         old_n = length(arguments(op.body))
@@ -396,8 +396,8 @@ end  # block mutation
 
     # Nested block parent is the entry block
     for inst in instructions(sci.entry)
-        if stmt(inst) isa IfOp
-            then_blk = stmt(inst).then_region
+        if inst[:stmt] isa IfOp
+            then_blk = inst[:stmt].then_region
             @test parent(then_blk) === sci.entry
             @test IRStructurizer.root(then_blk) === sci
             break
@@ -447,7 +447,7 @@ end
     end |> only
 
     for inst in instructions(sci.entry)
-        op = stmt(inst)
+        op = inst[:stmt]
         if op isa ForOp
             terms = reachable_terminators(op.body)
             @test !isempty(terms)
@@ -544,20 +544,20 @@ end
     @test Set(i.ssa_idx for i in post_insts) == Set(i.ssa_idx for i in pre_insts)
 
     # In preorder, the IfOp should come before instructions inside it
-    ifop_idx = findfirst(i -> stmt(i) isa IfOp, pre_insts)
+    ifop_idx = findfirst(i -> i[:stmt] isa IfOp, pre_insts)
     @test ifop_idx !== nothing
     # Instructionructions after the IfOp in preorder should include nested ones
     @test length(pre_insts) > ifop_idx
 
     # In postorder, the IfOp should come after instructions inside it
-    ifop_idx_post = findfirst(i -> stmt(i) isa IfOp, post_insts)
+    ifop_idx_post = findfirst(i -> i[:stmt] isa IfOp, post_insts)
     @test ifop_idx_post > 1  # nested instructions come first
 
     # Skip: don't recurse into IfOp
     skip_insts = Instruction[]
     walk(sci) do inst, block
         push!(skip_insts, inst)
-        stmt(inst) isa IfOp && return :skip
+        inst[:stmt] isa IfOp && return :skip
         return :advance
     end
     @test length(skip_insts) < length(pre_insts)
@@ -817,7 +817,7 @@ end  # use tracking
 
     found = false
     for inst in instructions(sci.entry)
-        op = stmt(inst)
+        op = inst[:stmt]
         op isa ForOp || continue
         c = carries(op)
         @test length(c) == length(op.init_values)
@@ -1156,7 +1156,7 @@ end  # loop carries
     # to test the type-based resolution path
     callee_ssa_idx = nothing
     for inst in instructions(block)
-        s = stmt(inst)
+        s = inst[:stmt]
         s isa Expr && s.head === :call || continue
         # This SSA defines a call result; create a synthetic :call that uses
         # a different SSA (one typed as a singleton function) as the callee.
@@ -1247,8 +1247,8 @@ end
 
     # Find an SSAValue defined in the entry block and look it up from a nested block
     for inst in instructions(sci.entry)
-        if stmt(inst) isa IfOp
-            ifop = stmt(inst)
+        if inst[:stmt] isa IfOp
+            ifop = inst[:stmt]
             then_blk = ifop.then_region
             # The condition SSAValue is defined in the entry block
             cond = ifop.condition
@@ -1274,7 +1274,7 @@ end
 
     found = false
     for inst in instructions(sci.entry)
-        op = stmt(inst)
+        op = inst[:stmt]
         op isa IRStructurizer.ControlFlowOp || continue
         for blk in blocks(op)
             if !isempty(arguments(blk))
@@ -1327,8 +1327,8 @@ end  # value_type(block, val)
     end |> only
 
     for inst in instructions(sci.entry)
-        if stmt(inst) isa IfOp
-            ops = operands(stmt(inst))
+        if inst[:stmt] isa IfOp
+            ops = operands(inst[:stmt])
             @test length(ops) == 1
             @test ops[1] isa SSAValue  # the condition
             break
@@ -1349,8 +1349,8 @@ end
 
     found = false
     walk(sci) do inst, block
-        if stmt(inst) isa ForOp
-            op = stmt(inst)
+        if inst[:stmt] isa ForOp
+            op = inst[:stmt]
             ops = operands(op)
             # lower, upper, step, plus any init_values
             @test length(ops) >= 3
@@ -1371,8 +1371,8 @@ end
 
     found = false
     walk(sci) do inst, block
-        if stmt(inst) isa WhileOp
-            op = stmt(inst)
+        if inst[:stmt] isa WhileOp
+            op = inst[:stmt]
             ops = operands(op)
             # init_values only (WhileOp has no explicit bounds)
             @test ops isa Vector
@@ -1397,8 +1397,8 @@ end
 
     found = false
     walk(sci) do inst, block
-        if stmt(inst) isa LoopOp
-            op = stmt(inst)
+        if inst[:stmt] isa LoopOp
+            op = inst[:stmt]
             ops = operands(op)
             @test ops isa Vector
             @test length(ops) == length(op.init_values)
@@ -1455,7 +1455,7 @@ end  # operands(block, inst)
     result = def(sci, SSAValue(inst1.ssa_idx))
     @test result !== nothing
     @test result.ssa_idx == inst1.ssa_idx
-    @test block(result) === sci.entry
+    @test result.block === sci.entry
 end
 
 @testset "nested block" begin
@@ -1465,13 +1465,13 @@ end
 
     # Find an SSAValue defined inside a nested block (then/else region)
     for inst in instructions(sci.entry)
-        if stmt(inst) isa IfOp
-            op = stmt(inst)
+        if inst[:stmt] isa IfOp
+            op = inst[:stmt]
             inner_inst = first(instructions(op.then_region))
             result = def(sci, SSAValue(inner_inst.ssa_idx))
             @test result !== nothing
             @test result.ssa_idx == inner_inst.ssa_idx
-            @test block(result) === op.then_region
+            @test result.block === op.then_region
             break
         end
     end
@@ -1525,8 +1525,8 @@ end  # def
     for_op = nothing
     for b in eachblock(sci.entry)
         for inst in instructions(b)
-            if stmt(inst) isa ForOp
-                for_op = stmt(inst)::ForOp
+            if inst[:stmt] isa ForOp
+                for_op = inst[:stmt]::ForOp
                 break
             end
         end
@@ -1600,13 +1600,13 @@ end
     # Find the IfOp
     if_inst = nothing
     for inst in instructions(sci.entry)
-        if stmt(inst) isa IfOp
+        if inst[:stmt] isa IfOp
             if_inst = inst
             break
         end
     end
     @test if_inst !== nothing
-    if_op = stmt(if_inst)::IfOp
+    if_op = if_inst[:stmt]::IfOp
 
     then_block = if_op.then_region
     then_insts = collect(instructions(then_block))

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -14,11 +14,12 @@
     @test !isempty(insts)
     @test all(i -> i isa Instruction, insts)
 
-    # Each Instruction bundles ssa_idx, stmt, type, flag
+    # Each Instruction is a handle exposing ssa_idx, stmt, type, flag
     inst = first(insts)
     @test value_type(inst) isa Type
     @test SSAValue(inst) isa SSAValue
-    @test inst.flag isa UInt32
+    @test flag(inst) isa UInt32
+    @test inst[:flag] === flag(inst)
 end
 
 @testset "per-stmt flag carried through from IRCode" begin
@@ -33,10 +34,32 @@ end
     for inst in instructions(sci.entry)
         s = stmt(inst)
         if s isa Expr && s.head === :call
-            (inst.flag & Core.Compiler.IR_FLAG_EFFECT_FREE) != 0 && (found_pure = true; break)
+            (flag(inst) & Core.Compiler.IR_FLAG_EFFECT_FREE) != 0 && (found_pure = true; break)
         end
     end
     @test found_pure
+end
+
+@testset "Instruction is a live handle" begin
+    # Regression: an Instruction held across a write to the underlying
+    # entry must reflect the latest stmt/type/flag. Pre-migration the
+    # Instruction stored snapshot copies — `inst[:type] = T; value_type(inst)`
+    # would round-trip but `inst.type` (direct field) wouldn't.
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+    inst = first(instructions(sci.entry))
+
+    inst[:type] = Float64
+    @test value_type(inst) === Float64
+    @test inst[:type] === Float64
+
+    inst[:flag] = UInt32(0)
+    @test flag(inst) === UInt32(0)
+
+    # A second handle to the same SSA index sees the same live entry.
+    other = sci.entry[inst.ssa_idx]
+    @test value_type(other) === Float64
 end
 
 @testset "arguments(block)" begin
@@ -355,7 +378,7 @@ end
         x + 1
     end |> only
 
-    bad_ref = Instruction(999999, nothing, Nothing, UInt32(0), Block())
+    bad_ref = Instruction(999999, Block())
     @test_throws KeyError insert_before!(sci.entry, bad_ref, Expr(:call, :x), Int)
 end
 
@@ -411,7 +434,7 @@ end
     @test found === sci.entry
 
     # Non-existent instruction returns nothing
-    @test findblock(sci, Instruction(999999, nothing, Nothing, UInt32(0), Block())) === nothing
+    @test findblock(sci, Instruction(999999, Block())) === nothing
 end
 
 @testset "reachable_terminators(block)" begin

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -591,7 +591,7 @@ end
 
     # Float64 type should be preserved in entry block types
     @test !isempty(sci.entry.body)
-    @test any(((_, entry),) -> entry.typ isa Type && entry.typ <: AbstractFloat, sci.entry.body)
+    @test any(p -> last(p).type isa Type && last(p).type <: AbstractFloat, sci.entry.body)
     @test @roundtrip (x -> x + 1.0)(3.14)
 end
 
@@ -650,7 +650,7 @@ end
     @test length(matches) == 1
     (_, entry) = only(matches)
     # Check that the result type is Tuple{} (no results), not Int
-    @test entry.typ === Tuple{}
+    @test entry.type === Tuple{}
 end
 
 @testset "while loop ConditionOp uses BlockArgs not SSAValues" begin


### PR DESCRIPTION
This branch finishes the migration to a `Core.Compiler.Instruction-style` API: `Instruction` becomes a thin `(ssa_idx, block)` handle whose every read and write resolves to the live `Block.body` entry. The Symbol-keyed `inst[:stmt]` / `inst[:type]` / `inst[:flag]` indexing is the canonical accessor, same shape as Julia's compiler internals.