### PR TITLE
Add `const_value(sci, x)` for world-anchored value lookup.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/IRStructurizer.jl
+++ b/src/IRStructurizer.jl
@@ -7,7 +7,8 @@ using Core.Compiler: IRCode, CFG, BasicBlock, InstructionStream, StmtRange,
                      construct_domtree, DomTree, dominates,
                      construct_postdomtree, PostDomTree, postdominates,
                      CFGReachability, bb_in_irreducible_loop,
-                     widenconst
+                     widenconst,
+                     WorldRange
 using Base: code_ircode
 
 # structured IR definitions

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -606,10 +606,20 @@ mutable struct StructuredIRCode
     #           val > 0 means anchor (val is another SSA idx to follow). empty!(line_map) wipes all.
     const debuginfo_table::Any
     const line_map::Dict{Int, Int}
+
+    # World-age range over which this IR is consistent. Carried from
+    # `IRCode.valid_worlds` at ingest. Anchors binding-partition lookups
+    # (see [`global_type`](@ref)) so module-binding type queries return the
+    # type the IR was inferred against, even if the world has advanced
+    # since. Defaults to the unbounded range for hand-built SCIs (tests,
+    # MWEs) and on Julia 1.11 (which lacks `IRCode.valid_worlds`).
+    const valid_worlds::WorldRange
 end
 
 StructuredIRCode(argtypes, sptypes, entry, max_ssa_idx) =
-    StructuredIRCode(argtypes, sptypes, entry, max_ssa_idx, 0, nothing, Dict{Int,Int}())
+    StructuredIRCode(argtypes, sptypes, entry, max_ssa_idx, 0, nothing,
+                     Dict{Int,Int}(),
+                     WorldRange(typemin(UInt), typemax(UInt)))
 
 function Base.copy(sci::StructuredIRCode)
     # Sever entry→SCI backref before deepcopy to avoid pulling in
@@ -623,6 +633,7 @@ function Base.copy(sci::StructuredIRCode)
         sci.max_ssa_idx, sci.max_arg_idx,
         sci.debuginfo_table,  # shared (read-only)
         copy(sci.line_map),
+        sci.valid_worlds,
     )
     new_sci.entry.parent = new_sci
     fix_parents!(new_sci.entry)
@@ -681,8 +692,17 @@ function StructuredIRCode(ir::IRCode; structurize::Bool=true, validate::Bool=tru
         end
     end
 
+    # Carry the IR's world-age range (1.12+; 1.11 doesn't have the field
+    # and also doesn't enforce binding-access world warnings, so the
+    # unbounded default is fine).
+    @static if VERSION >= v"1.12-"
+        valid_worlds = ir.valid_worlds
+    else
+        valid_worlds = WorldRange(typemin(UInt), typemax(UInt))
+    end
+
     sci = StructuredIRCode(argtypes, sptypes, entry, n, 0,
-                           debuginfo_table, line_map)
+                           debuginfo_table, line_map, valid_worlds)
 
     if structurize && n > 0
         entry, max_ssa, max_arg, updated_line_map =

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -16,7 +16,7 @@
  Block mutation (SSA-allocating operations)
 =============================================================================#
 
-public root, parent, walk_uses!, IndexedUseRef
+public root, parent, walk_uses!, IndexedUseRef, const_value
 export insert_before!, insert_after!, eachblock, findblock,
        new_block_arg!,
        resolve_call, iscall, callee, callargs,
@@ -190,6 +190,8 @@ Get the Julia type of an arbitrary IR value as visible from `block`.
 For `SSAValue`, searches the current block then walks up the parent chain.
 For `BlockArgument` and `Undef`, returns the type stored on the value.
 For `Argument`/`SlotNumber`, looks up in the root `StructuredIRCode.argtypes`.
+For `GlobalRef`, queries the binding partition at the SCI's
+`valid_worlds.max_world` (see [`const_value`](@ref)).
 For constants, returns `typeof(val)`.
 Returns `nothing` only for an `SSAValue` or `Argument` whose type cannot be found.
 """
@@ -215,7 +217,8 @@ function value_type(block::Block, @nospecialize(val))
         sci = root(block)
         return val.id <= length(sci.argtypes) ? sci.argtypes[val.id] : nothing
     elseif val isa GlobalRef
-        return typeof(getfield(val.mod, val.name))
+        sci = root(block)
+        return widenconst(global_lattice_element(val, sci.valid_worlds.max_world))
     elseif val isa QuoteNode
         return typeof(val.value)
     else
@@ -1311,4 +1314,80 @@ function move_after!(inst::Instruction, target::Instruction)
         end
     end
     return Instruction(inst.ssa_idx, dst)
+end
+
+
+#=============================================================================
+ Static-eval helpers
+=============================================================================#
+
+"""
+    const_value(sci::StructuredIRCode, x) -> Union{Some, Nothing}
+
+Return `Some(value)` when `x`'s value is statically known in `sci`,
+otherwise `nothing`. The Julia analog of `static_eval` in `codegen.cpp`:
+dispatches on every operand-position IR shape, recovers the value from
+inference's lattice when it's a `Const` or singleton, and returns the
+literal itself otherwise.
+
+`GlobalRef` lookups are anchored on `sci.valid_worlds` (captured at
+structurization from `IRCode.valid_worlds`) and read only binding-
+partition metadata — never `getfield(mod, name)`. So on 1.12+ this
+neither triggers the "access-to-binding-prior-to-its-definition-world"
+warning nor reflects post-inference rebinds.
+"""
+function const_value(sci::StructuredIRCode, @nospecialize(x))
+    x isa GlobalRef            && return from_type(global_lattice_element(x, sci.valid_worlds.max_world))
+    x isa QuoteNode            && return Some(x.value)
+    x isa Instruction          && return from_type(x[:type])
+    x isa BlockArgument        && return from_type(x.type)
+    x isa Core.SSAValue        && return const_value_ssa(sci, x)
+    x isa Core.Argument        && return (1 <= x.n <= length(sci.argtypes) ?
+                                           from_type(sci.argtypes[x.n]) : nothing)
+    # `MethodInstance` (and `CodeInstance`) appear as the first operand
+    # of `:invoke` Exprs but they're inference artifacts, not values
+    # — match `static_eval` (codegen.cpp:3245–46) by rejecting them
+    # explicitly so they don't fall through to the "literal" branch.
+    x isa Core.MethodInstance  && return nothing
+    x isa Core.CodeInstance    && return nothing
+    # Anything else — `x` is a literal, the value is itself.
+    return Some(x)
+end
+
+# Resolve an `SSAValue` storage tag to its def's type. Linear-scans
+# `eachblock` like `def`, just without materializing an `Instruction`.
+function const_value_ssa(sci::StructuredIRCode, ssa::Core.SSAValue)
+    inst = def(sci, ssa)
+    inst === nothing ? nothing : from_type(inst[:type])
+end
+
+# Internal: recover the value from a type slot. Handles both
+# `Compiler.Const(val)` (inference-narrowed to a specific value) and
+# singleton ghost types (one-instance types like `typeof(sin)`).
+# Mirrors `singleton_type` + `Const`-unwrap in one helper.
+function from_type(@nospecialize(rt))
+    rt === nothing && return nothing
+    rt isa Core.Compiler.Const && return Some(rt.val)
+    if rt isa Type && isdefined(rt, :instance)
+        return Some(rt.instance)
+    end
+    return nothing
+end
+
+# Internal: read a `GlobalRef`'s inferred lattice element at `world`.
+# Mirrors `Core.Compiler.abstract_eval_globalref_type`. Lattice elements
+# aren't part of the public surface; consumers go through `const_value`.
+@static if VERSION >= v"1.12-"
+    function global_lattice_element(g::GlobalRef, world::UInt)
+        binding = convert(Core.Binding, g)
+        partition = Core.Compiler.lookup_binding_partition(world, binding)
+        (_, (leaf_binding, leaf_partition)) =
+            Core.Compiler.walk_binding_partition(binding, partition, world)
+        return Core.Compiler.abstract_eval_partition_load(nothing, leaf_binding, leaf_partition).rt
+    end
+else
+    # 1.11 lacks the binding-partition API and doesn't have the world-age
+    # binding-access warning either, so the direct lookup is safe and the
+    # value (via `Const`) reflects the current binding state.
+    global_lattice_element(g::GlobalRef, ::UInt) = Core.Compiler.Const(getfield(g.mod, g.name))
 end

--- a/src/ir/validation.jl
+++ b/src/ir/validation.jl
@@ -98,7 +98,7 @@ end
 
 # Convenience method for testing: wrap block in minimal SCI
 function validate_terminators(entry::Block)
-    sci = StructuredIRCode(Any[], Any[], entry, 0, 0, nothing, Dict{Int,Int}())
+    sci = StructuredIRCode(Any[], Any[], entry, 0)
     return validate_terminators(sci)
 end
 

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1317,6 +1317,21 @@ end
     @test value_type(sci.entry, SSAValue(999999)) === nothing
 end
 
+@testset "GlobalRef" begin
+    # GlobalRef lookup must use the world-anchored binding-partition path
+    # (same as `const_value`) — never `getfield(mod, name)`. On 1.12+ that
+    # would trigger "access to binding ... in a world prior to its
+    # definition world" warnings whenever cuTile compiles a kernel that
+    # references a freshly-defined module-level const (the world is locked
+    # by `invoke_frozen` to a value before the const's definition).
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    @test value_type(sci.entry, GlobalRef(Base, :sin)) === typeof(sin)
+    @test value_type(sci.entry, GlobalRef(Base, :Base)) === Module
+end
+
 end  # value_type(block, val)
 
 @testset "operands(op::ControlFlowOp)" begin
@@ -1643,3 +1658,50 @@ end
     @test operands(block, 42) == Any[]
     @test operands(block, GlobalRef(Base, :+)) == Any[]
 end
+
+@testset "const_value" begin
+    # `const_value(sci, x)` returns `Some(value)` when `x`'s value is
+    # statically known across all operand-position IR-value shapes:
+    # GlobalRefs (anchored on `sci.valid_worlds`), QuoteNodes,
+    # Instructions/BlockArguments with statically-known type, raw
+    # SSAValue / Argument tags (looked up via def / argtypes), and
+    # plain literals.
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    # GlobalRef — function singletons infer to `Const(f)`.
+    @test IRStructurizer.const_value(sci, GlobalRef(Base, :+)) === Some(+)
+    @test IRStructurizer.const_value(sci, GlobalRef(Base, :sin)) === Some(sin)
+    @test IRStructurizer.const_value(sci, GlobalRef(Base, :Base)) === Some(Base)
+
+    # QuoteNode — value is the quoted expression.
+    @test IRStructurizer.const_value(sci, QuoteNode(:foo)) === Some(:foo)
+    @test IRStructurizer.const_value(sci, QuoteNode(42)) === Some(42)
+
+    # Plain literal — the value is itself.
+    @test IRStructurizer.const_value(sci, 42) === Some(42)
+    @test IRStructurizer.const_value(sci, 3.14) === Some(3.14)
+    @test IRStructurizer.const_value(sci, "hello") === Some("hello")
+
+    # Raw SSAValue — look up the def in the SCI; if its type is
+    # statically known, return the value. Defs that are method-call
+    # results (non-singleton, non-Const type) return `nothing`.
+    not_const_inst = first(instructions(sci.entry))
+    @test IRStructurizer.const_value(sci, SSAValue(not_const_inst.ssa_idx)) ===
+        IRStructurizer.const_value(sci, not_const_inst)
+
+    # Argument — `sci.argtypes[n]`. The closure's first arg is itself
+    # (typed `Any` for an anonymous closure), the second is `Int` —
+    # neither is a Const or singleton, so returns `nothing`.
+    @test IRStructurizer.const_value(sci, Core.Argument(2)) === nothing
+    @test IRStructurizer.const_value(sci, Core.Argument(99)) === nothing  # OOB
+
+    # Inference artifacts (MethodInstance / CodeInstance appearing as
+    # the first operand of `:invoke` Exprs) aren't values — explicitly
+    # reject so they don't fall through to the literal-fallback branch.
+    mi = first(Base.specializations(only(methods(sin, Tuple{Float64}))))
+    @test mi isa Core.MethodInstance
+    @test IRStructurizer.const_value(sci, mi) === nothing
+end
+


### PR DESCRIPTION
Two related additions:

1. `StructuredIRCode.valid_worlds::WorldRange` — carried from `IRCode.valid_worlds` at structurization (1.12+; defaults to the unbounded range on 1.11 / hand-built SCIs). Anchors module-binding queries to the world the IR was inferred against, so the answer doesn't drift if the world has advanced since.

2. `const_value(sci, x) -> Union{Some, Nothing}` — public helper that returns `Some(value)` when `x`'s value is statically known and `nothing` otherwise. The Julia analog of `static_eval` in `codegen.cpp`: dispatches on every operand-position IR shape (`GlobalRef`, `QuoteNode`, `Instruction`, `BlockArgument`, `Core.SSAValue`, `Core.Argument`, `Core.MethodInstance` / `Core.CodeInstance`, plus the literal fallback), recovers the value from inference's lattice when it's a `Const` or singleton ghost, and returns the literal itself otherwise.

   `GlobalRef` lookups read only binding-partition metadata (`Compiler.lookup_binding_partition` → `Compiler.walk_binding_partition` → `Compiler.abstract_eval_partition_load`), never `getfield(mod, name)`. So on 1.12+ this neither triggers the "access-to-binding-prior-to-its-definition-world" warning nor reflects post-inference rebinds.

This is the minimum surface downstream consumers (cuTile's intrinsic dispatch, in particular) need to inspect operand-position values without paying a `getfield` deref.