### PR TITLE
Fix `const_value` on 1.11 to reject non-const GlobalRefs.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IRStructurizer"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -1386,8 +1386,13 @@ end
         return Core.Compiler.abstract_eval_partition_load(nothing, leaf_binding, leaf_partition).rt
     end
 else
-    # 1.11 lacks the binding-partition API and doesn't have the world-age
-    # binding-access warning either, so the direct lookup is safe and the
-    # value (via `Const`) reflects the current binding state.
-    global_lattice_element(g::GlobalRef, ::UInt) = Core.Compiler.Const(getfield(g.mod, g.name))
+    # 1.11 lacks the binding-partition API. Delegate to the existing
+    # `abstract_eval_globalref_type`, which returns `Const(value)` for
+    # const bindings, the binding's declared type otherwise — same
+    # `from_type`-friendly shape as the 1.12+ path. Reading via
+    # `getfield(mod, name)` unconditionally would erase the const-vs-
+    # mutable distinction (every binding becomes `Const`), which lets
+    # mutable host globals leak into kernel IR as compile-time values.
+    global_lattice_element(g::GlobalRef, ::UInt) =
+        Core.Compiler.abstract_eval_globalref_type(g)
 end

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1675,6 +1675,14 @@ end
     @test IRStructurizer.const_value(sci, GlobalRef(Base, :sin)) === Some(sin)
     @test IRStructurizer.const_value(sci, GlobalRef(Base, :Base)) === Some(Base)
 
+    # Non-const GlobalRef — the binding type isn't a `Const` and isn't
+    # a singleton, so `const_value` returns `nothing`. `Base.stdout` is
+    # typed `IO` and rebound at runtime, so it must NOT leak as a
+    # compile-time value (consumers would silently capture a stale
+    # IOContext). This guards both the 1.12+ binding-partition path
+    # and the 1.11 fallback.
+    @test IRStructurizer.const_value(sci, GlobalRef(Base, :stdout)) === nothing
+
     # QuoteNode — value is the quoted expression.
     @test IRStructurizer.const_value(sci, QuoteNode(:foo)) === Some(:foo)
     @test IRStructurizer.const_value(sci, QuoteNode(42)) === Some(42)


### PR DESCRIPTION
The 1.11 fallback unconditionally returned `Const(getfield(...))`, erasing the const-vs-mutable distinction and leaking mutable host globals as compile-time values. Delegate to `abstract_eval_globalref_type` instead, matching the 1.12+ binding-partition shape.