### PR TITLE
Unify IR-operand type queries over an `argextype` core

### DIFF
--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -616,10 +616,18 @@ mutable struct StructuredIRCode
     const valid_worlds::WorldRange
 end
 
-StructuredIRCode(argtypes, sptypes, entry, max_ssa_idx) =
-    StructuredIRCode(argtypes, sptypes, entry, max_ssa_idx, 0, nothing,
-                     Dict{Int,Int}(),
-                     WorldRange(typemin(UInt), typemax(UInt)))
+# Minimal constructor for hand-built SCIs (tests, MWEs). Wires the parent
+# chain (entry → SCI, sub-blocks → containing block) so `root(block)`
+# walks succeed — the full `StructuredIRCode(ir::IRCode; ...)` constructor
+# does the same after structurization.
+function StructuredIRCode(argtypes, sptypes, entry, max_ssa_idx)
+    sci = StructuredIRCode(argtypes, sptypes, entry, max_ssa_idx, 0, nothing,
+                           Dict{Int,Int}(),
+                           WorldRange(typemin(UInt), typemax(UInt)))
+    sci.entry.parent = sci
+    fix_parents!(sci.entry)
+    return sci
+end
 
 function Base.copy(sci::StructuredIRCode)
     # Sever entry→SCI backref before deepcopy to avoid pulling in

--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -194,36 +194,14 @@ For `GlobalRef`, queries the binding partition at the SCI's
 `valid_worlds.max_world` (see [`const_value`](@ref)).
 For constants, returns `typeof(val)`.
 Returns `nothing` only for an `SSAValue` or `Argument` whose type cannot be found.
+
+The widened-type view over [`argextype`](@ref); call `const_value` for the
+static value (when known).
 """
 function value_type(block::Block, @nospecialize(val))
-    if val isa SSAValue
-        entry = get(block.body, val.id, nothing)
-        entry !== nothing && return entry.type
-        p = block.parent
-        while p isa Block
-            entry = get(p.body, val.id, nothing)
-            entry !== nothing && return entry.type
-            p = p.parent
-        end
-        return nothing
-    elseif val isa BlockArgument
-        return val.type
-    elseif val isa Undef
-        return val.type
-    elseif val isa Argument
-        sci = root(block)
-        return val.n <= length(sci.argtypes) ? sci.argtypes[val.n] : nothing
-    elseif val isa SlotNumber
-        sci = root(block)
-        return val.id <= length(sci.argtypes) ? sci.argtypes[val.id] : nothing
-    elseif val isa GlobalRef
-        sci = root(block)
-        return widenconst(global_lattice_element(val, sci.valid_worlds.max_world))
-    elseif val isa QuoteNode
-        return typeof(val.value)
-    else
-        return typeof(val)  # literal constant
-    end
+    lat = argextype(block, val)
+    lat === nothing && return nothing
+    return widenconst(lat)
 end
 
 """
@@ -1335,30 +1313,65 @@ structurization from `IRCode.valid_worlds`) and read only binding-
 partition metadata — never `getfield(mod, name)`. So on 1.12+ this
 neither triggers the "access-to-binding-prior-to-its-definition-world"
 warning nor reflects post-inference rebinds.
+
+The static-value view over [`argextype`](@ref); call `value_type` for the
+widened type instead.
 """
-function const_value(sci::StructuredIRCode, @nospecialize(x))
-    x isa GlobalRef            && return from_type(global_lattice_element(x, sci.valid_worlds.max_world))
-    x isa QuoteNode            && return Some(x.value)
-    x isa Instruction          && return from_type(x[:type])
-    x isa BlockArgument        && return from_type(x.type)
-    x isa Core.SSAValue        && return const_value_ssa(sci, x)
-    x isa Core.Argument        && return (1 <= x.n <= length(sci.argtypes) ?
-                                           from_type(sci.argtypes[x.n]) : nothing)
-    # `MethodInstance` (and `CodeInstance`) appear as the first operand
-    # of `:invoke` Exprs but they're inference artifacts, not values
-    # — match `static_eval` (codegen.cpp:3245–46) by rejecting them
-    # explicitly so they don't fall through to the "literal" branch.
-    x isa Core.MethodInstance  && return nothing
-    x isa Core.CodeInstance    && return nothing
-    # Anything else — `x` is a literal, the value is itself.
-    return Some(x)
+const_value(sci::StructuredIRCode, @nospecialize(x)) = from_type(argextype(sci, x))
+
+"""
+    argextype(src, val) -> Any
+
+Inferred lattice element for an operand-position IR value, either a
+`Compiler.Const(v)` (statically known value), a widened `Type`, or
+`nothing` for inference artifacts (`MethodInstance`/`CodeInstance`) and
+unresolvable `SSAValue`/`Argument` tags. Mirrors `Core.Compiler.argextype`
+against `StructuredIRCode`-shaped IR.
+
+`src` selects the SSA lookup strategy: a `Block` walks the parent chain
+(structured scoping); a `StructuredIRCode` does a flat scan via [`def`](@ref).
+
+Consumers go through [`value_type`](@ref) (widened type) or
+[`const_value`](@ref) (static value when known).
+"""
+function argextype(src::Union{Block,StructuredIRCode}, @nospecialize(val))
+    val isa BlockArgument && return val.type
+    val isa Undef && return val.type
+    val isa Instruction && return val[:type]
+    # `MethodInstance` and `CodeInstance` appear as the first operand of
+    # `:invoke` Exprs but they're inference artifacts, not values — match
+    # `static_eval` (codegen.cpp:3245–46) by rejecting them explicitly so
+    # they don't fall through to the literal branch.
+    (val isa Core.MethodInstance || val isa Core.CodeInstance) && return nothing
+    val isa QuoteNode && return Core.Compiler.Const(val.value)
+    val isa SSAValue && return _argextype_ssa(src, val)
+    # The remaining shapes need access to `sci.argtypes`/`sci.valid_worlds`.
+    sci = src isa StructuredIRCode ? src : root(src)
+    val isa Argument && return 1 <= val.n <= length(sci.argtypes) ? sci.argtypes[val.n] : nothing
+    val isa SlotNumber && return 1 <= val.id <= length(sci.argtypes) ? sci.argtypes[val.id] : nothing
+    val isa GlobalRef && return global_lattice_element(val, sci.valid_worlds.max_world)
+    # Anything else — `val` is a literal; wrap as `Const` so widenconst /
+    # from_type recover `typeof(val)` / `Some(val)` respectively.
+    return Core.Compiler.Const(val)
 end
 
-# Resolve an `SSAValue` storage tag to its def's type. Linear-scans
-# `eachblock` like `def`, just without materializing an `Instruction`.
-function const_value_ssa(sci::StructuredIRCode, ssa::Core.SSAValue)
-    inst = def(sci, ssa)
-    inst === nothing ? nothing : from_type(inst[:type])
+# SSA type lookup: parent-chain walk (Block, structured scope) vs
+# flat scan via `def` (SCI, no scope info available).
+function _argextype_ssa(block::Block, val::SSAValue)
+    entry = get(block.body, val.id, nothing)
+    entry !== nothing && return entry.type
+    p = block.parent
+    while p isa Block
+        entry = get(p.body, val.id, nothing)
+        entry !== nothing && return entry.type
+        p = p.parent
+    end
+    return nothing
+end
+
+function _argextype_ssa(sci::StructuredIRCode, val::SSAValue)
+    inst = def(sci, val)
+    inst === nothing ? nothing : inst[:type]
 end
 
 # Internal: recover the value from a type slot. Handles both

--- a/src/ir/validation.jl
+++ b/src/ir/validation.jl
@@ -177,8 +177,8 @@ function validate_if_terminators!(errors::Vector{String}, sci::StructuredIRCode,
             end
             for i in 1:min(arity, length(expected))
                 Ti = expected[i]
-                check_yield_type!(errors, sci, then_term.values[i], Ti, idx, i, "then")
-                check_yield_type!(errors, sci, else_term.values[i], Ti, idx, i, "else")
+                check_yield_type!(errors, op.then_region, then_term.values[i], Ti, idx, i, "then")
+                check_yield_type!(errors, op.else_region, else_term.values[i], Ti, idx, i, "else")
             end
         end
     end
@@ -191,12 +191,14 @@ end
 # Check a single yield value against the IfOp's declared per-position type.
 # `Undef` placeholders (used for uninitialized slots on one branch) are skipped
 # — their recorded type is already the declared slot type, so the <: check is
-# trivially satisfied, but an explicit skip keeps intent clear.
-function check_yield_type!(errors::Vector{String}, sci::StructuredIRCode,
+# trivially satisfied, but an explicit skip keeps intent clear. `block` is the
+# yielding region, so `value_type` walks the parent chain and resolves SSAs
+# defined in the surrounding scope.
+function check_yield_type!(errors::Vector{String}, block::Block,
                             @nospecialize(value), @nospecialize(expected),
                             idx::Int, pos::Int, branch::String)
     value isa Undef && return
-    ty = resolve_type(sci, value)
+    ty = value_type(block, value)
     ty === nothing && return
     if !(ty <: expected)
         push!(errors, "IfOp at %$idx: $branch yield at position $pos has type $ty, not <: declared $expected")
@@ -433,39 +435,3 @@ function validate_ssa_uniqueness(sci::StructuredIRCode)
     return true
 end
 
-#=============================================================================
- Type Resolution for IRValues
-=============================================================================#
-
-"""
-    resolve_type(sci::StructuredIRCode, value::IRValue) -> Any
-
-Resolve the Julia type of an IRValue.
-Returns `nothing` if the type cannot be resolved.
-"""
-function resolve_type end
-
-resolve_type(sci::StructuredIRCode, value::Undef) = value.type
-
-resolve_type(sci::StructuredIRCode, value::BlockArgument) = value.type
-
-resolve_type(sci::StructuredIRCode, value::Argument) = sci.argtypes[value.n]
-
-resolve_type(sci::StructuredIRCode, value::SlotNumber) = sci.argtypes[value.id]
-
-resolve_type(sci::StructuredIRCode, value::QuoteNode) = typeof(value.value)
-
-resolve_type(sci::StructuredIRCode, value::GlobalRef) =
-    widenconst(global_lattice_element(value, sci.valid_worlds.max_world))
-
-# Constants: return their runtime type
-resolve_type(sci::StructuredIRCode, value) = typeof(value)
-
-# SSAValue: search the structured IR for its definition
-function resolve_type(sci::StructuredIRCode, value::SSAValue)
-    for block in eachblock(sci)
-        entry = get(block.body, value.id, nothing)
-        entry !== nothing && return entry.type
-    end
-    return nothing
-end

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1346,6 +1346,51 @@ end
 
 end  # value_type(block, val)
 
+@testset "argextype" begin
+    # `argextype` is the lattice-element primitive `value_type` and
+    # `const_value` share. It returns the same shapes as Julia's
+    # `Compiler.argextype`: `Compiler.Const(v)` for statically known
+    # values, a widened `Type` for SSA defs / args / globals, and
+    # `nothing` for inference artifacts.
+    sci, _ = code_structured(Tuple{Int}) do x::Int
+        x + 1
+    end |> only
+
+    Const = Core.Compiler.Const
+
+    # QuoteNode and literals → Const-wrapped (so widenconst recovers
+    # the type and from_type recovers the value).
+    @test IRStructurizer.argextype(sci.entry, QuoteNode(:foo)) === Const(:foo)
+    @test IRStructurizer.argextype(sci.entry, 42) === Const(42)
+    @test IRStructurizer.argextype(sci.entry, Base) === Const(Base)
+
+    # Argument → argtypes lookup, with bounds check.
+    @test IRStructurizer.argextype(sci.entry, Core.Argument(2)) === sci.argtypes[2]
+    @test IRStructurizer.argextype(sci.entry, Core.Argument(99)) === nothing
+
+    # SlotNumber resolves through argtypes the same way as Argument.
+    @test IRStructurizer.argextype(sci.entry, Core.SlotNumber(2)) === sci.argtypes[2]
+    @test IRStructurizer.argextype(sci.entry, Core.SlotNumber(99)) === nothing
+
+    # GlobalRef → binding-partition lattice element (a `Const` for const
+    # singletons, a widened type otherwise).
+    @test IRStructurizer.argextype(sci.entry, GlobalRef(Base, :sin)) === Const(sin)
+
+    # Inference artifacts → nothing (not values).
+    mi = first(Base.specializations(only(methods(sin, Tuple{Float64}))))
+    @test IRStructurizer.argextype(sci.entry, mi) === nothing
+
+    # SSA lookup: Block walks the parent chain (structured scoping),
+    # StructuredIRCode does a flat scan. Both find a def in the entry,
+    # but they differ on SSAs not reachable from a given block — verified
+    # implicitly by the value_type/const_value testsets above.
+    inst = first(instructions(sci.entry))
+    @test IRStructurizer.argextype(sci.entry, SSAValue(inst.ssa_idx)) === inst[:type]
+    @test IRStructurizer.argextype(sci, SSAValue(inst.ssa_idx)) === inst[:type]
+    @test IRStructurizer.argextype(sci.entry, SSAValue(999999)) === nothing
+    @test IRStructurizer.argextype(sci, SSAValue(999999)) === nothing
+end
+
 @testset "operands(op::ControlFlowOp)" begin
 
 @testset "IfOp" begin
@@ -1716,6 +1761,12 @@ end
     # neither is a Const or singleton, so returns `nothing`.
     @test IRStructurizer.const_value(sci, Core.Argument(2)) === nothing
     @test IRStructurizer.const_value(sci, Core.Argument(99)) === nothing  # OOB
+
+    # SlotNumber routes through argtypes the same way as Argument — a
+    # slot reference is a position, not a value, so the old literal-
+    # fallback behavior (returning `Some(SlotNumber(n))`) was wrong.
+    @test IRStructurizer.const_value(sci, Core.SlotNumber(2)) === nothing
+    @test IRStructurizer.const_value(sci, Core.SlotNumber(99)) === nothing  # OOB
 
     # Inference artifacts (MethodInstance / CodeInstance appearing as
     # the first operand of `:invoke` Exprs) aren't values — explicitly

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -403,6 +403,18 @@ end  # block mutation
             break
         end
     end
+
+    # Hand-built SCIs via the 4-arg constructor also wire the parent chain,
+    # so `root` walks succeed on tests/MWEs that don't go through `IRCode`.
+    then_blk = Block(); then_blk.terminator = YieldOp(Any[Core.Argument(2)])
+    else_blk = Block(); else_blk.terminator = YieldOp(Any[Core.Argument(2)])
+    entry = Block()
+    push!(entry, 1, IfOp(true, then_blk, else_blk), Tuple{Int})
+    entry.terminator = Core.ReturnNode(nothing)
+    sci_manual = StructuredIRCode(Any[Any, Int], Any[], entry, 10)
+    @test parent(sci_manual.entry) === sci_manual
+    @test parent(then_blk) === entry
+    @test IRStructurizer.root(then_blk) === sci_manual
 end
 
 @testset "eachblock(sci)" begin


### PR DESCRIPTION
`value_type`, `const_value`, and `resolve_type` were three parallel `if`-`elseif`/dispatch tables over the same IR-operand shape set, drifting independently (see e.g. #40, adding `QuoteNode`/`GlobalRef` to the third copy when the first two already handled it).

Collapse them to one lattice-element primitive, mirroring `Core.Compiler.argextype` + `widenconst`/`Const`-unwrap:

```
value_type(block, val) = widenconst(argextype(block, val))
const_value(sci, val)  = from_type(argextype(sci, val))
```