### PR TITLE
Thread PiNode-referenced loop values out as exit values

### DIFF
--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -461,6 +461,10 @@ function stmt_ssa_uses(@nospecialize(stmt))
         return (stmt.cond,)
     elseif stmt isa ReturnNode && isdefined(stmt, :val) && stmt.val isa SSAValue
         return (stmt.val,)
+    elseif stmt isa PiNode && stmt.val isa SSAValue
+        # A `PiNode`'s refined value is a real use — without this, a post-loop
+        # type-assertion on a loop-internal SSA isn't threaded out as an exit.
+        return (stmt.val,)
     else
         return ()
     end

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1701,6 +1701,17 @@ end
     @test moved_pos < if_pos
 end
 
+@testset "stmt_ssa_uses sees PiNode operand" begin
+    # A `PiNode`'s refined value is a real use. Missing it lets a post-loop
+    # type-assertion on a loop-internal SSA escape detection, so the value is
+    # never threaded out as a loop result → an out-of-scope reference in a
+    # sibling region. (Regression: AcceleratedKernels' nd-reduction kernel.)
+    @test collect(IRStructurizer.stmt_ssa_uses(Core.PiNode(SSAValue(7), Int))) ==
+          [SSAValue(7)]
+    # A PiNode over a non-SSA value (e.g. an Argument) contributes no SSA use.
+    @test isempty(collect(IRStructurizer.stmt_ssa_uses(Core.PiNode(Core.Argument(2), Int))))
+end
+
 @testset "operands dispatches on IR types" begin
     # PiNode
     pi = Core.PiNode(SSAValue(1), Int)


### PR DESCRIPTION
## Problem

`find_extra_exit_values` detects loop-internal SSA values that are used *after* the loop, so they can be threaded out as loop results. It does this by scanning each exit statement's operands via `stmt_ssa_uses`.

`stmt_ssa_uses` handled `Expr`, `SSAValue`, `GotoIfNot` and `ReturnNode` — but **not `PiNode`**. So a post-loop type-assertion `PiNode(%v, T)` on a loop-internal `%v` was invisible to escape analysis: `%v` was never exported as a loop result, and a sibling region referencing it produced an out-of-scope SSA use.

This surfaces in AcceleratedKernels' `mapreduce_nd_by_block!` kernel, whose second reduction loop reads a `Union{Int32,Int64}` accumulator carried out of the first loop through a `PiNode`. The resulting structured IR has the second loop referencing a value defined inside the first loop — which a downstream MLIR consumer rejects with a dominance/"use of undeclared SSA value" error.

## Fix

Add a `PiNode` case to `stmt_ssa_uses` so its refined value is counted as a use. With that, `find_extra_exit_values` sees the escape, threads the value out via a `getfield` on the loop result, and downstream uses resolve to the result rather than the loop-internal def.

## Test

Adds a focused unit test asserting `stmt_ssa_uses` returns the operand of an SSA-valued `PiNode` (and nothing for a `PiNode` over a non-SSA value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)