### PR TITLE
Loop/branch structurization fixes: sequential-ifs, short-circuit bodies, PiNode exits, :invoke-callee use, loop-exit throws

### DIFF
--- a/src/ir/utilities.jl
+++ b/src/ir/utilities.jl
@@ -441,9 +441,12 @@ is_value_like_stmt(@nospecialize(s)) =
 # Fallback for unknown statement types (no-op)
 walk_uses!(f, ::Any) = nothing
 
-# Expr: walk operands
+# Expr: walk operands. For `:invoke`, args are [CodeInstance/MI, callee, args…];
+# the callee (args[2]) is a real SSA use (e.g. a closure being applied) and must
+# be walked — so start at 2. The CodeInstance/MI at args[1] is not a value, so
+# skipping it (by starting at 2) is correct for both `:invoke` and `:call`.
 function walk_uses!(f, expr::Expr)
-    start = expr.head === :invoke ? 3 : 2
+    start = 2
     for i in start:length(expr.args)
         f(IndexedUseRef(expr.args, i))
     end
@@ -597,7 +600,9 @@ end
 """Check if a statement references `target` in any operand position."""
 function _references(@nospecialize(stmt), @nospecialize(target))
     if stmt isa Expr
-        start = stmt.head === :invoke ? 3 : 2
+        # `:invoke` callee (args[2]) is a real use; the MI at args[1] is not a
+        # value, so start at 2 for both `:invoke` and `:call`.
+        start = 2
         for i in start:length(stmt.args)
             normalize_key(stmt.args[i]) == target && return true
         end

--- a/src/structurize.jl
+++ b/src/structurize.jl
@@ -29,7 +29,12 @@ function StructurizeCtx(ir::IRCode, line_map::Dict{Int, Int}=Dict{Int, Int}())
     postdomtree = construct_postdomtree(ir)
     loops = compute_natural_loops(ir, domtree)
     n = length(ir.stmts.stmt)
-    StructurizeCtx(ir, domtree, postdomtree, loops, n + 1, 1, copy(ir.stmts.type), Dict{Int,Int}(), line_map)
+    # `ctx.types` feeds only structural positions (op result / block-arg / Undef
+    # types), which must be concrete `Type`s. Widen so a lattice element (e.g.
+    # `Core.Const` on a phi with one literal edge) can't land there; statement
+    # types copied verbatim by the walk keep their original `ir.stmts.type`.
+    types = Any[widenconst(t) for t in ir.stmts.type]
+    StructurizeCtx(ir, domtree, postdomtree, loops, n + 1, 1, types, Dict{Int,Int}(), line_map)
 end
 
 alloc_ssa!(ctx::StructurizeCtx) = (idx = ctx.next_ssa; ctx.next_ssa += 1; idx)

--- a/src/structurize.jl
+++ b/src/structurize.jl
@@ -40,6 +40,17 @@ end
 alloc_ssa!(ctx::StructurizeCtx) = (idx = ctx.next_ssa; ctx.next_ssa += 1; idx)
 alloc_arg!(ctx::StructurizeCtx) = (id = ctx.next_arg; ctx.next_arg += 1; id)
 
+"""Record the structural type of a (possibly freshly allocated) SSA index.
+`ctx.types` is sized to the original IR; grow it so synthesized indices (e.g. a
+materialized short-circuit discriminator) are addressable like original ones."""
+function set_ssa_type!(ctx::StructurizeCtx, ssa_idx::Int, @nospecialize(T))
+    if ssa_idx > length(ctx.types)
+        resize!(ctx.types, ssa_idx)
+    end
+    ctx.types[ssa_idx] = T
+    return T
+end
+
 """Map a synthesized SSA index to the same source location as an existing SSA index."""
 function anchor_line!(ctx::StructurizeCtx, new_ssa::Int, source_ssa::Int)
     haskey(ctx.line_map, source_ssa) || return

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -668,6 +668,10 @@ function stmt_ssa_uses(@nospecialize(stmt))
         return (stmt.cond,)
     elseif stmt isa ReturnNode && isdefined(stmt, :val) && stmt.val isa SSAValue
         return (stmt.val,)
+    elseif stmt isa PiNode && stmt.val isa SSAValue
+        # A `PiNode`'s refined value is a real use — without this, a post-loop
+        # type-assertion on a loop-internal SSA isn't threaded out as an exit.
+        return (stmt.val,)
     else
         return ()
     end

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -137,6 +137,7 @@ function emit_ifop_result!(block::Block, if_op::IfOp, phi_indices::Vector{Int},
     if_ssa = alloc_ssa!(ctx)
     remap = ctx.ssa_remap
     if !isempty(phi_indices)
+        # `phi_types` come pre-widened from `ctx.types`.
         result_type = Tuple{phi_types...}
         push!(block, if_ssa, if_op, result_type)
         line_anchor != 0 && anchor_line!(ctx, if_ssa, line_anchor)
@@ -205,11 +206,13 @@ function emit_loop!(block::Block, ctx::StructurizeCtx, header::Int,
         fresh = alloc_ssa!(ctx)
         ctx.ssa_remap[ex.ssa_idx] = fresh
         anchor_line!(ctx, fresh, ex.ssa_idx)
-        push!(init_values, Undef(ex.type))
+        # `ex.type` bypasses `ctx.types`, so widen it here too.
+        ext = widenconst(ex.type)
+        push!(init_values, Undef(ext))
         push!(carried_values, SSAValue(fresh))  # carry the fresh-index value
         push!(phi_indices, ex.ssa_idx)           # getfield OUTSIDE uses original
-        push!(phi_types, ex.type)
-        arg = BlockArgument(alloc_arg!(ctx), ex.type)
+        push!(phi_types, ext)
+        arg = BlockArgument(alloc_arg!(ctx), ext)
         push!(body.args, arg)
     end
 

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -251,8 +251,9 @@ function find_gated_body(ctx::StructurizeCtx, current::Int,
             for si in first(bb.stmts):last(bb.stmts)
                 stmt = ir.stmts.stmt[si]
                 if stmt isa PhiNode
-                    for (k, v) in enumerate(stmt.values)
-                        isassigned(stmt.values, k) || continue
+                    for k in eachindex(stmt.values)
+                        isassigned(stmt.values, k) || continue   # undef phi slot
+                        v = stmt.values[k]
                         v isa SSAValue && v.id ∈ body_defs || continue
                         if !(merge_in_region && blk_idx == merge &&
                              Int(stmt.edges[k]) ∈ body_region)

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -74,6 +74,209 @@ function find_branch_regions(ctx::StructurizeCtx, current::Int,
     return then_blocks, else_blocks, merge
 end
 
+"""
+    branch_continuation(ctx, current, true_dest, false_dest, then_blocks,
+                         else_blocks, region_blocks)
+        -> (continuation_entries::Vector{Int}, notContinuation::Set{Int})
+
+Compute the branch continuation MLIR-style, mirroring
+`transformToStructuredCFBranches` in CFGToSCF.cpp (~lines 969-1098).
+
+`notContinuation` (CFGToSCF.cpp `notContinuation`) = `current` plus every block
+SOLELY dominated by one of the branch successors — exactly `then_blocks` and
+`else_blocks` (each is the dominator subtree of a single-predecessor successor,
+which is how `find_branch_regions` already computes them; CFGToSCF.cpp lines
+977-990).
+
+The continuation is then derived from the **edges leaving `notContinuation`**
+(CFGToSCF.cpp lines 1054-1090, the `continuationEdges` loop), NOT from
+post-dominance. This is the part that makes the analysis robust to virtual exits
+(throw/`÷`/undef paths give `ipdom == 0`) and to bodies that fan into the
+continuation at several internal points: every such region-exit edge target is a
+continuation entry. Region-exit/return-like blocks (no successors, CFGToSCF.cpp
+`isRegionExitBlock`) contribute nothing here — they stay as case-2 unstructured
+sub-regions handled by the recursive walk. The distinct edge targets are the
+continuation entry blocks, deduplicated preserving first-seen order.
+
+A continuation entry may leave `region_blocks` entirely: when a gated body is
+NESTED in another, the inner branch's skip path targets the SHARED outer merge,
+which the outer multiplexer left out of the inner region. We therefore keep
+out-of-region targets as entries, but DROP loop boundaries (`loop_ctx`): a
+back-edge to the header is a continue and an edge out of the loop is a break —
+neither is part of this branch's forward continuation.
+"""
+function branch_continuation(ctx::StructurizeCtx, current::Int,
+                              true_dest::Int, false_dest::Int,
+                              then_blocks::Set{Int}, else_blocks::Set{Int},
+                              region_blocks::Set{Int},
+                              loop_ctx::Union{Nothing, LoopCtx}=nothing)
+    ir = ctx.ir
+    nblocks = length(ir.cfg.blocks)
+
+    # notContinuation = branch entry ∪ arm regions; continuation = distinct
+    # targets of edges leaving it (edge targets, not post-dominance → survives
+    # virtual exits). MLIR transformToStructuredCFBranches:
+    # https://github.com/llvm/llvm-project/blob/cabad14763b27802296b44b3b5e507f6a4f7a3c5/mlir/lib/Transforms/Utils/CFGToSCF.cpp
+    notContinuation = Set{Int}((current,))
+    union!(notContinuation, then_blocks)
+    union!(notContinuation, else_blocks)
+
+    scan = Int[current]
+    append!(scan, then_blocks)
+    append!(scan, else_blocks)
+
+    entries = Int[]
+    seen = Set{Int}()
+    for b in scan
+        1 <= b <= nblocks || continue
+        bb = ir.cfg.blocks[b]
+        isempty(bb.succs) && continue   # return-like block: no continuation edge
+        for succ in bb.succs
+            succ ∈ notContinuation && continue
+            # loop boundary (continue/break) — handled by the loop machinery
+            if loop_ctx !== nothing &&
+               (succ == loop_ctx.header || succ ∉ loop_ctx.loop_blocks)
+                continue
+            end
+            dominates(ctx.domtree, succ, b) && continue   # back-edge to enclosing header
+            if succ ∉ seen
+                push!(seen, succ)
+                push!(entries, succ)
+            end
+        end
+    end
+    return entries, notContinuation
+end
+
+"""
+    find_gated_body(...) -> (body_entry, body_region, merge) | nothing
+
+A short-circuit-guarded body (`if a||b { body }`, `&&`, value forms): the body is
+reached from BOTH arms, so it lands in neither then/else region and the branch
+continuation has TWO entries. Returns the gated body, its region, and the merge
+it exits to; `nothing` if the shape doesn't match (→ ordinary IfOp path).
+
+The continuation is computed MLIR-style (`branch_continuation`), not via `ipdom`
+— robust to virtual exits and to a body that fans into `merge` at several
+internal points. `emit_gated_branch!` then gates the body under one `scf.if` via
+the edge multiplexer, structurized ONCE (no duplication).
+
+Requires: exactly 2 continuation entries; the `body` (dominated by `current`)
+exits only to `merge` (which may sit outside `region_blocks` — a nested gated
+body's shared outer merge); the body region is fully enclosed (preds from
+arms/body, succs to body/merge/return-like); no body value escapes except a phi
+value at `merge` (threaded out as a multiplexer result).
+"""
+function find_gated_body(ctx::StructurizeCtx, current::Int,
+                          true_dest::Int, false_dest::Int,
+                          then_blocks::Set{Int}, else_blocks::Set{Int},
+                          region_blocks::Set{Int},
+                          loop_ctx::Union{Nothing, LoopCtx}=nothing)
+    ir = ctx.ir
+    nblocks = length(ir.cfg.blocks)
+
+    entries, _notContinuation = branch_continuation(
+        ctx, current, true_dest, false_dest, then_blocks, else_blocks,
+        region_blocks, loop_ctx)
+
+    # Only a 2-entry continuation needs the multiplexer (else: ordinary IfOp path).
+    length(entries) == 2 || return nothing
+
+    # arms the selector fans into (incl. `current` for the `&&` shape, where
+    # false_dest is the body reached directly from current)
+    arms = union(then_blocks, else_blocks)
+    push!(arms, true_dest); push!(arms, false_dest); push!(arms, current)
+
+    # 2-entry case: gate the `body` (dominated by current, exits only to `merge`),
+    # then fall through to `merge`.
+    A, B = entries[1], entries[2]
+    for (body_entry, merge) in ((A, B), (B, A))
+        body_entry == merge && continue
+        dominates(ctx.domtree, current, body_entry) || continue
+        merge <= nblocks || continue
+
+        # body region = body_entry's dominator subtree, up to (not incl.) `merge`
+        dominated = Set{Int}()
+        collect_dominated!(dominated, ctx.domtree, body_entry, region_blocks)
+        body_region = Set{Int}()
+        ok = true
+        for b in dominated
+            b == merge && continue
+            dominates(ctx.domtree, merge, b) && continue
+            push!(body_region, b)
+        end
+        (isempty(body_region) || body_entry ∉ body_region) && continue
+
+        # closure: body preds from arms/body (single entry); succs to body/merge/
+        # return-like (throw/unreachable blocks stay nested in the body)
+        ok = true
+        for b in body_region
+            b <= nblocks || (ok = false; break)
+            for pred in ir.cfg.blocks[b].preds
+                pred ∈ body_region && continue
+                if !(b == body_entry && pred ∈ arms)
+                    ok = false; break
+                end
+            end
+            ok || break
+            for succ in ir.cfg.blocks[b].succs
+                (succ ∈ body_region || succ == merge) && continue
+                # return-like succ (throw/unreachable): keep it in the body
+                if succ <= nblocks && isempty(ir.cfg.blocks[succ].succs) &&
+                   succ ∈ region_blocks
+                    push!(body_region, succ)
+                    continue
+                end
+                ok = false; break
+            end
+            ok || break
+        end
+        ok || continue
+
+        # must be reached from an arm, and not a self-loop entry
+        body_entry ∈ ir.cfg.blocks[body_entry].preds && continue
+        any(p -> p ∈ arms, ir.cfg.blocks[body_entry].preds) || continue
+
+        # a body value may escape only as a phi value at `merge` (threaded out as a
+        # multiplexer result, so def and use share scope); else it'd be stranded → bail
+        merge_in_region = merge ∈ region_blocks
+        body_defs = Set{Int}()
+        for b in body_region, si in first(ir.cfg.blocks[b].stmts):last(ir.cfg.blocks[b].stmts)
+            push!(body_defs, si)
+        end
+        escapes = false
+        for blk_idx in 1:nblocks
+            blk_idx ∈ body_region && continue
+            bb = ir.cfg.blocks[blk_idx]
+            for si in first(bb.stmts):last(bb.stmts)
+                stmt = ir.stmts.stmt[si]
+                if stmt isa PhiNode
+                    for (k, v) in enumerate(stmt.values)
+                        isassigned(stmt.values, k) || continue
+                        v isa SSAValue && v.id ∈ body_defs || continue
+                        if !(merge_in_region && blk_idx == merge &&
+                             Int(stmt.edges[k]) ∈ body_region)
+                            escapes = true; break
+                        end
+                    end
+                else
+                    for u in stmt_ssa_uses(stmt)
+                        if u.id ∈ body_defs
+                            escapes = true; break
+                        end
+                    end
+                end
+                escapes && break
+            end
+            escapes && break
+        end
+        escapes && continue
+
+        return body_entry, body_region, merge
+    end
+    return nothing
+end
+
 """Count predecessors of `block` in `region` that are not loop backedges to `block`."""
 function count_non_backedge_preds(ir::IRCode, ctx::StructurizeCtx, block::Int, region::Set{Int})
     count = 0

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -203,9 +203,11 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
     merge_phis = if merge !== nothing && merge ∈ region_blocks &&
                    (!haskey(ctx.loop_map, merge) || is_multi_entry_header)
         phis = extract_merge_phis(ir, merge, region_blocks)
-        # If merge has no phis, check its successors for phis
-        # (handles pass-through merge blocks like in || patterns)
-        if isempty(phis)
+        # No phis: absorb a genuine pass-through (no-phi block forwarding
+        # unconditionally) and use its successor's phis — the || pattern. Gate on
+        # a single successor: a multi-successor merge is itself a branch (e.g. a
+        # sequential `if` sharing the condition) and must not be absorbed.
+        if isempty(phis) && length(ir.cfg.blocks[merge].succs) == 1
             for succ in ir.cfg.blocks[merge].succs
                 if succ ∈ region_blocks && !haskey(ctx.loop_map, succ)
                     succ_phis = extract_merge_phis(ir, succ, region_blocks)

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -42,19 +42,11 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
     nblocks = length(ir.cfg.blocks)
     current = entry
     last_block = entry
-    # Track the dest that caused the walker to step out of `region_blocks`. Used
-    # by the exit-yield logic to inline-structurize past the region boundary
-    # when the merge phi value is defined past `last_block` (short-circuit
-    # `||`-style patterns).
-    exit_dest::Union{Nothing, Int} = nothing
 
-    # Advance the walker toward `target`; if that step leaves the region, record
-    # the target in `exit_dest` so the exit-yield logic can find the value.
-    advance = target -> begin
-        nc = resolve_dest(target, region_blocks, loop_ctx, block)
-        nc === nothing && target !== nothing && (exit_dest = target)
-        nc
-    end
+    # Advance the walker toward `target`, resolving loop boundaries
+    # (back-edge → ContinueOp, exit → BreakOp); returns nothing if `target`
+    # leaves the region.
+    advance = target -> resolve_dest(target, region_blocks, loop_ctx, block)
 
     while current !== nothing && current ∈ region_blocks
         last_block = current
@@ -104,7 +96,7 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
 
     # Region ended — set terminator if not already set
     if block.terminator === nothing && merge_phis !== nothing
-        set_exit_yield!(block, ir, ctx, merge_phis, last_block, exit_dest, loop_ctx)
+        set_exit_yield!(block, ir, ctx, merge_phis, last_block)
     end
 
     return block
@@ -187,6 +179,20 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
     # Determine branch regions and merge block using dominance
     then_blocks, else_blocks, merge = find_branch_regions(
         ctx, current, true_dest, false_dest, region_blocks)
+
+    # Short-circuit-guarded body (`if a || b { body }`, `a && b`, value forms):
+    # the body is the multi-entry continuation reached from BOTH arms, so it falls
+    # into neither then/else region. Materialize the combined predicate as a
+    # boolean region selector and emit the body ONCE under `scf.if` — MLIR's
+    # transformCFGToSCF edge multiplexer, no body duplication.
+    gated = find_gated_body(ctx, current, true_dest, false_dest,
+                            then_blocks, else_blocks, region_blocks, loop_ctx)
+    if gated !== nothing
+        body_entry, body_region, gate_merge = gated
+        return emit_gated_branch!(block, ctx, current, cond, true_dest, false_dest,
+                                  then_blocks, else_blocks, body_entry, body_region,
+                                  gate_merge, region_blocks, loop_ctx)
+    end
 
     # If merge exists and is in region, extract its phis.
     # Skip phis at loop headers — UNLESS the header has multiple non-loop predecessors
@@ -310,6 +316,111 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
     end
 end
 
+"""
+    emit_gated_branch!(...) -> next
+
+Emit a short-circuit-guarded body (`if a || b { body }; rest`) as MLIR's
+`transformCFGToSCF` edge multiplexer — the body is structured ONCE, never
+duplicated.
+
+The continuation has two entry blocks (`body`, `rest=merge`). The multiplexer
+specializes to:
+
+1. An entry `IfOp(cond)` that materializes a boolean region selector — the
+   combined predicate `a || b` — as block result `disc`. Reusing the merge-phi
+   machinery this is a synthetic phi `disc = φ(reaches-body => true, reaches-rest
+   => false)`; the recursive walk routes each arm leaf to the right constant, so
+   nested branches (`a || b || c`) become nested IfOps yielding `disc`. When the
+   continuation carries values (a value-producing `||`/`&&`), the multiplexer
+   also yields, per merge phi, the value on the skip-body (arm→merge) edges as
+   additional block results.
+2. A single `scf.if disc { body } { skip }` that runs the body ONCE. Its results
+   are the merge phi values: the body arm yields the body→merge values; the skip
+   arm forwards the values the entry IfOp produced for the skip path.
+3. The walk continues at `merge`, where the original phi SSAs are now defined by
+   the gated IfOp's results.
+"""
+# MLIR edge multiplexer for a short-circuit-guarded body (CFGToSCF.cpp
+# `EdgeMultiplexer`: https://github.com/llvm/llvm-project/blob/cabad14763b27802296b44b3b5e507f6a4f7a3c5/mlir/lib/Transforms/Utils/CFGToSCF.cpp):
+# the entry IfOp yields a boolean selector (the combined predicate) + skip-path
+# merge values, then one `scf.if selector { body }` runs the body once.
+function emit_gated_branch!(block::Block, ctx::StructurizeCtx, current::Int,
+                            cond, true_dest::Int, false_dest::Int,
+                            then_blocks::Set{Int}, else_blocks::Set{Int},
+                            body_entry::Int, body_region::Set{Int},
+                            merge::Int, region_blocks::Set{Int},
+                            loop_ctx::Union{Nothing, LoopCtx})
+    ir = ctx.ir
+    branch_anchor = last(ir.cfg.blocks[current].stmts)
+
+    # merge phis (only if `merge` is in this region; an outer-merge nested body
+    # has no escaping value). skip_preds = arm→merge edges (not in the body).
+    mp = merge ∈ region_blocks ? extract_merge_phis(ir, merge, region_blocks) : MergePhiInfo[]
+    skip_preds = Int[p for p in ir.cfg.blocks[merge].preds if p ∉ body_region]
+
+    # --- 1. Entry IfOp: yield the selector + skip-path values ---
+    # Selector phi: true on body-reaching arms, false on skip arms; skip phis
+    # forward each merge phi's skip-edge value (Undef on the body edge).
+    disc_ssa = alloc_ssa!(ctx)
+    set_ssa_type!(ctx, disc_ssa, Bool)
+    disc_ev = Dict{Int,Any}(body_entry => true)
+    for p in skip_preds; disc_ev[p] = false; end
+    disc_phis = MergePhiInfo[MergePhiInfo(disc_ssa, disc_ev)]
+
+    skip_ssas = Int[]   # entry-IfOp result holding each phi's skip-path value
+    for phi in mp
+        s = alloc_ssa!(ctx)
+        set_ssa_type!(ctx, s, ctx.types[phi.ssa_idx])
+        push!(skip_ssas, s)
+        ev = Dict{Int,Any}(body_entry => Undef(ctx.types[phi.ssa_idx]))
+        for p in skip_preds
+            ev[p] = get(phi.edge_values, p, Undef(ctx.types[phi.ssa_idx]))
+        end
+        push!(disc_phis, MergePhiInfo(s, ev))
+    end
+
+    then_blk = if !isempty(then_blocks)
+        structurize_region!(ctx, true_dest, then_blocks; merge_phis=disc_phis, loop_ctx=loop_ctx)
+    else
+        make_empty_branch_block(true_dest, current, disc_phis, loop_ctx, ir, ctx)
+    end
+    else_blk = if !isempty(else_blocks)
+        structurize_region!(ctx, false_dest, else_blocks; merge_phis=disc_phis, loop_ctx=loop_ctx)
+    else
+        make_empty_branch_block(false_dest, current, disc_phis, loop_ctx, ir, ctx)
+    end
+    set_branch_yields!(then_blk, disc_phis, then_blocks, current, ir, block, ctx)
+    set_branch_yields!(else_blk, disc_phis, else_blocks, current, ir, block, ctx)
+
+    disc_if = IfOp(cond, then_blk, else_blk)
+    disc_indices = Int[p.ssa_idx for p in disc_phis]
+    disc_types = Any[ctx.types[i] for i in disc_indices]
+    emit_ifop_result!(block, disc_if, disc_indices, disc_types, ctx, branch_anchor)
+
+    # --- 2. Structurize the body ONCE, yielding its merge-phi contributions ---
+    body_merge_phis = isempty(mp) ? nothing : mp
+    body_blk = structurize_region!(ctx, body_entry, body_region;
+                                   merge_phis=body_merge_phis, loop_ctx=loop_ctx)
+    set_yield_if_needed!(body_blk)
+
+    # --- 3. Gate it: scf.if disc { body } { forward skip values } ---
+    skip_blk = Block()
+    skip_blk.terminator = YieldOp(IRValue[SSAValue(s) for s in skip_ssas])
+    body_if = IfOp(SSAValue(disc_ssa), body_blk, skip_blk)
+    if isempty(mp)
+        if_ssa = alloc_ssa!(ctx)
+        push!(block, if_ssa, body_if, Tuple{})
+        anchor_line!(ctx, if_ssa, branch_anchor)
+    else
+        phi_indices = Int[p.ssa_idx for p in mp]
+        phi_types = Any[ctx.types[p.ssa_idx] for p in mp]
+        emit_ifop_result!(block, body_if, phi_indices, phi_types, ctx, branch_anchor)
+    end
+
+    # --- 4. Continue at merge ---
+    return merge
+end
+
 """Set yield terminator on a branch block for merge phis, if not already set."""
 function set_branch_yields!(blk::Block, merge_phis::Vector{MergePhiInfo},
                             branch_blocks::Set{Int}, branch_entry::Int,
@@ -342,71 +453,15 @@ function make_empty_branch_block(dest::Int, from::Int,
             return b
         end
     end
-    # Merge phis? Use reachability from dest to find the right phi edge value.
+    # Merge phis? Use reachability from dest to find the right phi-edge value and
+    # yield it directly. Multi-entry continuations (the short-circuit `&&`/`||`
+    # shape, where a value is defined in a block between the arms and the merge)
+    # are handled upstream by the `emit_gated_branch!` edge multiplexer, so the
+    # value is always visible here — no tail duplication needed.
     if merge_phis !== nothing && !isempty(merge_phis)
         pred = find_exit_predecessor(merge_phis, Set{Int}([dest]), from, ir)
-        # If `pred` lies past `dest` (the BFS walked beyond `dest` to find a phi
-        # predecessor), the yield value is defined inside `dest`'s subtree and is
-        # not visible in the empty block. Inline-structurize that subtree with
-        # fresh SSA indices so the value is materialized locally. This handles
-        # short-circuit `&&`/`||` patterns where the merge tail is reached from
-        # multiple sibling regions.
-        #
-        # `pred != from` skips duplication when the merge phi has a direct edge
-        # from the branch source itself: the empty block IS that edge, so
-        # yielding the from-edge value directly is correct.
-        if pred != dest && pred != from && dominates(ctx.domtree, dest, pred)
-            tail_duplicate_branch!(b, dest, merge_phis, loop_ctx, ir, ctx)
-        else
-            b.terminator = make_yield_for_edge(ir, merge_phis, pred, b, ctx)
-        end
+        b.terminator = make_yield_for_edge(ir, merge_phis, pred, b, ctx)
     end
-    return b
-end
-
-"""
-Inline-structurize `dest`'s dominator subtree into `b` with fresh SSA indices.
-
-Used by `make_empty_branch_block` when a branch must yield a value defined in a
-block past `dest` (the short-circuit `&&`/`||` pattern, where the merge tail is
-shared between sibling regions). The dominator subtree is closed under
-predecessors, so we can structurize it as a self-contained region; cloning with
-fresh indices avoids violating SSA uniqueness when the same tail also appears
-in a sibling branch.
-"""
-function tail_duplicate_branch!(b::Block, dest::Int,
-                                 merge_phis::Vector{MergePhiInfo},
-                                 loop_ctx::Union{Nothing, LoopCtx},
-                                 ir::IRCode, ctx::StructurizeCtx)
-    nblocks = length(ir.cfg.blocks)
-    full_region = Set{Int}(1:nblocks)
-    subtree = Set{Int}()
-    collect_dominated!(subtree, ctx.domtree, dest, full_region)
-
-    saved_remap = copy(ctx.ssa_remap)
-    for bb_idx in subtree
-        bb = ir.cfg.blocks[bb_idx]
-        for si in first(bb.stmts):last(bb.stmts)
-            stmt = ir.stmts.stmt[si]
-            (stmt isa GotoNode || stmt isa GotoIfNot ||
-             stmt isa ReturnNode) && continue
-            haskey(ctx.ssa_remap, si) && continue
-            fresh = alloc_ssa!(ctx)
-            ctx.ssa_remap[si] = fresh
-            anchor_line!(ctx, fresh, si)
-        end
-    end
-
-    sub_block = structurize_region!(ctx, dest, subtree;
-                                     merge_phis=merge_phis,
-                                     loop_ctx=loop_ctx)
-
-    ctx.ssa_remap = saved_remap
-
-    for (idx, entry) in sub_block.body
-        push!(b.body, (idx, entry.stmt, entry.type, entry.flag))
-    end
-    b.terminator = sub_block.terminator
     return b
 end
 
@@ -479,23 +534,15 @@ function make_yield_for_edge(ir::IRCode, merge_phis::Vector{MergePhiInfo},
 end
 
 """
-Set a region's exit terminator on `blk`. Mirrors `make_empty_branch_block`'s
-short-circuit handling: when the resolved phi predecessor lies past
-`last_block` and we know the out-of-region successor `exit_dest` that caused
-the walker to leave, inline-structurize `exit_dest`'s dominator subtree so the
-yield value is materialized locally. Otherwise fall back to a direct
-`make_yield_for_edge`.
+Set a region's exit terminator on `blk`: resolve which phi-edge predecessor this
+region reaches and yield that value. Multi-entry continuations (short-circuit
+`&&`/`||`) are handled upstream by the `emit_gated_branch!` edge multiplexer, so
+the yield value is always visible — no tail duplication.
 """
 function set_exit_yield!(blk::Block, ir::IRCode, ctx::StructurizeCtx,
-                          merge_phis::Vector{MergePhiInfo}, last_block::Int,
-                          exit_dest::Union{Nothing, Int}, loop_ctx::Union{Nothing, LoopCtx})
+                          merge_phis::Vector{MergePhiInfo}, last_block::Int)
     pred = find_exit_predecessor(merge_phis, Set{Int}([last_block]), last_block, ir)
-    if pred != last_block && exit_dest !== nothing &&
-       dominates(ctx.domtree, exit_dest, pred)
-        tail_duplicate_branch!(blk, exit_dest, merge_phis, loop_ctx, ir, ctx)
-    else
-        blk.terminator = make_yield_for_edge(ir, merge_phis, pred, blk, ctx)
-    end
+    blk.terminator = make_yield_for_edge(ir, merge_phis, pred, blk, ctx)
     return blk.terminator
 end
 

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -46,7 +46,7 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
     # Advance the walker toward `target`, resolving loop boundaries
     # (back-edge → ContinueOp, exit → BreakOp); returns nothing if `target`
     # leaves the region.
-    advance = target -> resolve_dest(target, region_blocks, loop_ctx, block)
+    advance = target -> resolve_dest(target, region_blocks, loop_ctx, block, ctx)
 
     while current !== nothing && current ∈ region_blocks
         last_block = current
@@ -107,7 +107,8 @@ Resolve a destination block, checking loop boundaries.
 Returns the dest to continue walking, or nothing if it's a loop exit/back-edge.
 """
 function resolve_dest(dest, region_blocks::Set{Int},
-                       loop_ctx::Union{Nothing, LoopCtx}, block::Block)
+                       loop_ctx::Union{Nothing, LoopCtx}, block::Block,
+                       ctx::Union{Nothing, StructurizeCtx}=nothing)
     dest === nothing && return nothing
     if loop_ctx !== nothing
         if dest == loop_ctx.header
@@ -115,12 +116,38 @@ function resolve_dest(dest, region_blocks::Set{Int},
                 (block.terminator = ContinueOp(copy(loop_ctx.carried_values)))
             return nothing
         elseif dest ∉ loop_ctx.loop_blocks
+            # A loop-exit edge to a dead-end throw/unreachable block (no successors,
+            # terminal type Union{}) is NOT a normal break: collapsing it to a
+            # BreakOp would discard the throw. Emit the block's statements in place
+            # and terminate with `unreachable` (`ReturnNode()`), matching the
+            # non-loop throw path (which keeps the throw call ::Union{}).
+            if ctx !== nothing && block.terminator === nothing &&
+               is_throw_exit(ctx.ir, dest)
+                emit_throw_exit!(block, ctx, dest)
+                return nothing
+            end
             block.terminator === nothing &&
                 (block.terminator = BreakOp(copy(loop_ctx.break_values)))
             return nothing
         end
     end
     dest ∈ region_blocks ? dest : nothing
+end
+
+"""A dead-end throw/unreachable block: no successors and terminal type `Union{}`."""
+function is_throw_exit(ir::IRCode, dest::Int)
+    1 <= dest <= length(ir.cfg.blocks) || return false
+    bb = ir.cfg.blocks[dest]
+    isempty(bb.succs) || return false
+    return ir.stmts.type[last(bb.stmts)] === Union{}
+end
+
+"""Emit a dead-end throw block's statements into `block` and set the `unreachable`
+(`ReturnNode()`) terminator — keeps the throw call instead of dropping it as a break."""
+function emit_throw_exit!(block::Block, ctx::StructurizeCtx, dest::Int)
+    emit_block_stmts!(block, ctx, dest)
+    block.terminator = ReturnNode()  # unreachable
+    return block
 end
 
 #=============================================================================
@@ -449,6 +476,12 @@ function make_empty_branch_block(dest::Int, from::Int,
             b.terminator = ContinueOp(copy(loop_ctx.carried_values))
             return b
         elseif dest ∉ loop_ctx.loop_blocks
+            # Dead-end throw/unreachable exit: emit its statements + `unreachable`
+            # instead of collapsing to a BreakOp (which would drop the throw).
+            if is_throw_exit(ir, dest)
+                emit_throw_exit!(b, ctx, dest)
+                return b
+            end
             b.terminator = BreakOp(copy(loop_ctx.break_values))
             return b
         end

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1701,6 +1701,17 @@ end
     @test moved_pos < if_pos
 end
 
+@testset "stmt_ssa_uses sees PiNode operand" begin
+    # A `PiNode`'s refined value is a real use. Missing it lets a post-loop
+    # type-assertion on a loop-internal SSA escape detection, so the value is
+    # never threaded out as a loop result → an out-of-scope reference in a
+    # sibling region. (Regression: AcceleratedKernels' nd-reduction kernel.)
+    @test collect(IRStructurizer.stmt_ssa_uses(Core.PiNode(SSAValue(7), Int))) ==
+          [SSAValue(7)]
+    # A PiNode over a non-SSA value (e.g. an Argument) contributes no SSA use.
+    @test isempty(collect(IRStructurizer.stmt_ssa_uses(Core.PiNode(Core.Argument(2), Int))))
+end
+
 @testset "operands dispatches on IR types" begin
     # PiNode
     pi = Core.PiNode(SSAValue(1), Int)

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -658,6 +658,23 @@ end
     @test length(idx[SSAValue(1)]) == 1  # ReturnNode terminator
 end
 
+@testset "uses tracks :invoke callee (args[2])" begin
+    # `:invoke` args are [CodeInstance/MI, callee, args…]. The callee (args[2])
+    # is a real SSA use — e.g. an outlined closure being applied; missing it lets
+    # DCE drop the statement defining the callee, dangling the invoke. The MI at
+    # args[1] is not a value (here a stand-in Symbol), so it's never a use.
+    block = Block()
+    push!(block.body, (1, Expr(:invoke, :stand_in_mi, SSAValue(0), SSAValue(2)), Int))
+    block.terminator = ReturnNode(SSAValue(1))
+    idx = uses(block)
+    @test length(idx[SSAValue(0)]) == 1   # callee counted as a use
+    @test length(idx[SSAValue(2)]) == 1   # the call argument
+    # replace_uses! must rewrite the callee operand too.
+    replace_uses!(block, SSAValue(0), SSAValue(99))
+    @test isempty(uses(block)[SSAValue(0)])
+    @test length(uses(block)[SSAValue(99)]) == 1
+end
+
 @testset "replace_uses! mutates all positions" begin
     # Verify replace_uses! works on Expr args
     block = Block()

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -584,6 +584,39 @@ end  # nested control flow
     @test @roundtrip f_dup(5)
 end
 
+@testset "sequential ifs sharing a condition in a loop" begin
+    # KA tail-block masking shape: sequential `if cond` diamonds sharing an
+    # opaque condition. `opaque`: non-folding cond; `sink`: side effect, no value.
+    @noinline opaque(b) = Base.compilerbarrier(:type, b)::Bool
+    @noinline sink(x) = (Base.donotdelete(x); nothing)
+
+    # 2nd if updates an escaping accumulator; the 1st if's phi-free merge must not
+    # be absorbed as a pass-through (→ "SSA values used but not defined").
+    function seq_ifs_loop(n::Int, c::Bool)
+        cond = opaque(c)
+        acc = 0
+        for kt in 1:n
+            if cond; sink(kt); end
+            if cond; acc += kt; end
+        end
+        return acc
+    end
+    @test @roundtrip seq_ifs_loop(5, true)
+    @test @roundtrip seq_ifs_loop(5, false)
+    @test @roundtrip seq_ifs_loop(10, true)
+
+    # `y` is defined on one edge only → its merge phi is typed `Core.Const`,
+    # illegal in a structural type position unless widened.
+    function const_merge_phi(c::Bool)
+        cond = opaque(c)
+        if cond; x = 3.0; else; x = 4.0; end
+        if cond; y = 1.0; end
+        return cond ? y : x
+    end
+    @test @roundtrip const_merge_phi(true)
+    @test @roundtrip const_merge_phi(false)
+end
+
 @testset "type preservation" begin
     sci, _ = code_structured(Tuple{Float64}) do x::Float64
         x + 1.0

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -1264,6 +1264,28 @@ end
     end
 end
 
+@testset "short-circuit guard with an undef phi slot in the escape check" begin
+    # Regression (found via AcceleratedKernels' block merge-sort): a value defined
+    # only inside a `||`-guarded body and used inside a SECOND `||`-guard gives the
+    # merge phi an undefined incoming slot. find_gated_body's escape check iterated
+    # `enumerate(phi.values)`, reading the undef slot before its `isassigned` guard
+    # → UndefRefError. It now reads the value only after the guard.
+    function undef_phi(c1::Bool, c2::Bool, n::Int)
+        if c1 || c2
+            t = n + 1
+        end
+        s = 0
+        if c1 || c2
+            s = t
+        end
+        return s
+    end
+    sci_up, _ = code_structured(undef_phi, Tuple{Bool, Bool, Int}) |> only  # must not throw
+    for c1 in (false, true), c2 in (false, true)
+        @test execute(sci_up, c1, c2, 7) == undef_phi(c1, c2, 7)
+    end
+end
+
 @testset "loop exit through fallthrough (not GotoIfNot dest)" begin
     # Regression test: find_loop_exit_condition only checked if GotoIfNot.dest
     # exited the loop, but missed the case where the *fallthrough* path (cond=true)

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -1050,13 +1050,8 @@ end
 end
 
 @testset "short-circuit && with sub-diamond in else branch" begin
-    # Regression: short-circuit `&&` whose `else` path is itself a non-trivial
-    # diamond produces a CFG where the false_dest has multi-pred (the branch
-    # source AND the inner condition's false edge). `find_branch_regions`
-    # leaves else_blocks empty and `make_empty_branch_block` would yield a
-    # value defined inside the (un-structurized) subtree — failing
-    # `validate_ssa_defs`. The fix tail-duplicates the dominator subtree of
-    # the empty branch's destination with fresh SSA indices.
+    # `&&` whose else-path is itself a diamond: the multi-entry continuation (the
+    # inner diamond) is structured ONCE behind the materialized predicate.
     f_and_diamond = (x::Int, y::Int, z::Int) -> begin
         a = if x > 0 && y > 0
             x * y
@@ -1072,14 +1067,14 @@ end
     @test code_structured(f_and_diamond, Tuple{Int, Int, Int}) isa Vector
     @test @roundtrip f_and_diamond(1,  1,  1)   # %5 && %9 → x*y
     @test @roundtrip f_and_diamond(-1, 1,  1)   # outer-else → z+1
-    @test @roundtrip f_and_diamond(1, -1,  1)   # then → inner-else (cloned subtree) → z+1
+    @test @roundtrip f_and_diamond(1, -1,  1)   # then → inner-else → z+1
     @test @roundtrip f_and_diamond(-1,-1, -1)   # outer-else → -z
-    @test @roundtrip f_and_diamond(1, -1, -1)   # then → inner-else (cloned subtree) → -z
+    @test @roundtrip f_and_diamond(1, -1, -1)   # then → inner-else → -z
 end
 
 @testset "short-circuit || with sub-diamond in then branch" begin
-    # Symmetric to the `&&` case: the merge-tail is reached from sibling
-    # regions via `||`. Triggers `set_exit_yield!`'s tail-duplication path.
+    # Symmetric `||`: the value-producing then-body (inner diamond) is the
+    # multi-entry continuation; gated once, body + skip values threaded as results.
     f_or_diamond = (x::Int, y::Int, z::Int) -> begin
         a = if x > 0 || y > 0
             if z > 0
@@ -1098,6 +1093,175 @@ end
     @test @roundtrip f_or_diamond(1, -1,  1)
     @test @roundtrip f_or_diamond(-1,-1, -1)
     @test @roundtrip f_or_diamond(1, -1, -1)
+end
+
+@testset "short-circuit || guarding a phi-free side-effect body" begin
+    # `if a || b { side_effect }` with a phi-free body: previously dropped (the
+    # body lands in neither arm region). Now gated once via the multiplexer.
+    @noinline opaque(b) = Base.compilerbarrier(:type, b)::Bool
+
+    # Recursively count `:call` statements whose callee is `GlobalRef(_, fname)`
+    # across all nested control-flow blocks. Used to assert the side-effecting
+    # store appears exactly once (no body duplication).
+    function count_calls(blk::Block, fname::Symbol)
+        n = 0
+        for (_, entry) in blk.body
+            stmt = entry.stmt
+            if stmt isa Expr && stmt.head === :call
+                callee = get(stmt.args, 1, nothing)
+                callee isa GlobalRef && callee.name === fname && (n += 1)
+            elseif stmt isa ControlFlowOp
+                for sub in IRStructurizer.blocks(stmt)
+                    n += count_calls(sub, fname)
+                end
+            end
+        end
+        return n
+    end
+
+    # --- || guarding a Ref store (no value escapes) ---
+    function orfun!(r::Base.RefValue{Int}, flag::Bool, g::Int)
+        if opaque(flag) || g != 0
+            r[] = 99
+        end
+        return nothing
+    end
+    sci_or, _ = code_structured(orfun!, Tuple{Base.RefValue{Int}, Bool, Int}) |> only
+    # The store appears EXACTLY ONCE — no body duplication.
+    @test count_calls(sci_or.entry, :setfield!) == 1
+    for (flag, g) in ((false, 0), (false, 5), (true, 0), (true, 5))
+        r = Ref(0)
+        execute(sci_or, r, flag, g)
+        @test r[] == ((flag || g != 0) ? 99 : 0)
+    end
+
+    # --- && guarding a Ref store (regression: must still gate correctly) ---
+    function andfun!(r::Base.RefValue{Int}, a::Bool, b::Bool)
+        if opaque(a) && opaque(b)
+            r[] = 99
+        end
+        return nothing
+    end
+    sci_and, _ = code_structured(andfun!, Tuple{Base.RefValue{Int}, Bool, Bool}) |> only
+    @test count_calls(sci_and.entry, :setfield!) == 1
+    for (a, b) in ((false, false), (false, true), (true, false), (true, true))
+        r = Ref(0)
+        execute(sci_and, r, a, b)
+        @test r[] == ((a && b) ? 99 : 0)
+    end
+
+    # --- 3-way || (a || b || c) guarding a side effect (generalizes) ---
+    function or3!(r::Base.RefValue{Int}, a::Bool, b::Bool, c::Int)
+        if opaque(a) || opaque(b) || c != 0
+            r[] = 99
+        end
+        return nothing
+    end
+    sci_or3, _ = code_structured(or3!, Tuple{Base.RefValue{Int}, Bool, Bool, Int}) |> only
+    @test count_calls(sci_or3.entry, :setfield!) == 1
+    for (a, b, c) in ((false, false, 0), (false, false, 5),
+                      (false, true, 0), (true, false, 0), (true, true, 9))
+        r = Ref(0)
+        execute(sci_or3, r, a, b, c)
+        @test r[] == ((a || b || c != 0) ? 99 : 0)
+    end
+
+    # --- mixed (a || b) && c guarding a side effect (must stay correct) ---
+    function mixfun!(r::Base.RefValue{Int}, a::Bool, b::Bool, c::Bool)
+        if (opaque(a) || opaque(b)) && opaque(c)
+            r[] = 99
+        end
+        return nothing
+    end
+    sci_mix, _ = code_structured(mixfun!, Tuple{Base.RefValue{Int}, Bool, Bool, Bool}) |> only
+    @test count_calls(sci_mix.entry, :setfield!) == 1
+    for (a, b, c) in ((false, false, true), (true, false, false),
+                      (true, false, true), (false, true, true), (true, true, true))
+        r = Ref(0)
+        execute(sci_mix, r, a, b, c)
+        @test r[] == (((a || b) && c) ? 99 : 0)
+    end
+
+    # --- || guarding a side effect INSIDE a loop (KA tail-masking shape) ---
+    # The body BB sits in the loop body; blocks dominated by the branch but past
+    # the join (the loop latch) must NOT be swallowed into the gated body.
+    function or_in_loop!(r::Base.RefValue{Int}, c::Bool, n::Int)
+        for k in 1:n
+            if opaque(c) || k > 2
+                r[] += k
+            end
+        end
+        return nothing
+    end
+    sci_loop, _ = code_structured(or_in_loop!, Tuple{Base.RefValue{Int}, Bool, Int}) |> only
+    @test count_calls(sci_loop.entry, :setfield!) == 1
+    for (c, n) in ((false, 5), (true, 5), (false, 2), (true, 0))
+        r = Ref(0)
+        execute(sci_loop, r, c, n)
+        expected = 0
+        for k in 1:n
+            (c || k > 2) && (expected += k)
+        end
+        @test r[] == expected
+    end
+
+    # --- nested ||-guarded bodies (a gated body inside another) ---
+    # The inner `||`'s continuation is the shared outer merge, which lies outside
+    # the outer body region — the multiplexer must still gate the inner body once.
+    function nested!(r::Base.RefValue{Int}, a::Bool, b::Bool, c::Bool, d::Bool)
+        if opaque(a) || opaque(b)
+            r[] += 1
+            if opaque(c) || opaque(d)
+                r[] += 10
+            end
+        end
+        return nothing
+    end
+    sci_nest, _ = code_structured(nested!, Tuple{Base.RefValue{Int}, Bool, Bool, Bool, Bool}) |> only
+    @test count_calls(sci_nest.entry, :setfield!) == 2   # `r[]+=1` and `r[]+=10`, once each
+    for a in (false, true), b in (false, true), c in (false, true), d in (false, true)
+        r = Ref(0)
+        execute(sci_nest, r, a, b, c, d)
+        expected = 0
+        if a || b
+            expected += 1
+            (c || d) && (expected += 10)
+        end
+        @test r[] == expected
+    end
+
+    # `||`-guarded body that fans into the continuation at multiple internal points
+    # with throw paths (the AcceleratedKernels exclusive-scan shape). Throws give
+    # `ipdom(current) == 0`, so an ipdom heuristic fails; the edge-target
+    # continuation finds {body, merge} robustly. Body must run iff (inc || iblk!=0).
+    function ak_shape!(r::Base.RefValue{Int}, inc::Bool, iblk::Int, k::Int, v::Vector{Int})
+        if opaque(inc) || iblk != 0
+            # body: a guarded array access (throw path → ipdom 0) and an internal
+            # early exit to the continuation, mirroring the `kt == last` early-out.
+            x = v[k]            # bounds check → throw/unreachable path
+            if k == 1
+                r[] = x         # internal exit #1 to the continuation
+            else
+                r[] = x + 100   # internal exit #2 to the continuation
+            end
+        end
+        return nothing
+    end
+    tt = Tuple{Base.RefValue{Int}, Bool, Int, Int, Vector{Int}}
+    sci_ak, _ = code_structured(ak_shape!, tt) |> only
+    # The two body stores stay once each — no tail duplication of the body.
+    @test count_calls(sci_ak.entry, :setfield!) == 2
+    vv = [11, 22, 33]
+    for inc in (false, true), iblk in (0, 2), k in (1, 3)
+        r = Ref(-1)
+        execute(sci_ak, r, inc, iblk, k, vv)
+        expected = -1
+        if inc || iblk != 0
+            x = vv[k]
+            expected = (k == 1) ? x : x + 100
+        end
+        @test r[] == expected
+    end
 end
 
 @testset "loop exit through fallthrough (not GotoIfNot dest)" begin

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -1726,3 +1726,29 @@ end  # Julia for-in-range integration
     # All block args must be unique (no two equal values)
     @test length(all_args) == length(unique(all_args))
 end
+
+@testset "throw inside a loop is preserved (not dropped as a bare break)" begin
+    # A throw INSIDE a counted loop exits the loop to a dead-end (no-successors,
+    # Union{}-typed) block. Previously that block was collapsed to a bare BreakOp,
+    # silently DROPPING the throw — the function returned normally on bad input.
+    # The exit-block statements (the throw) must now be preserved (emitted in place,
+    # terminated by `unreachable`/ReturnNode()).
+    function loop_throw(a::Vector{Float32}, n::Int)
+        acc = 0.0f0
+        for k in 1:n
+            x = @inbounds a[k]
+            if x < 0.0f0
+                throw(DomainError(x))
+            end
+            acc += x
+        end
+        return acc
+    end
+    sci, _ = code_structured(loop_throw, Tuple{Vector{Float32}, Int}) |> only
+    # Behavioral: good input sums; a negative element THROWS. (The bug returned
+    # normally — the loop-exit throw block had been silently dropped to a bare
+    # break.) Executing the structured IR exercises that the throw both survived
+    # structurization and fires.
+    @test execute(sci, Float32[1, 2, 3], 3) == 6.0f0
+    @test_throws DomainError execute(sci, Float32[1, -2, 3], 3)
+end


### PR DESCRIPTION
A batch of structurization-correctness fixes accumulated while retargeting through MLIR. Each is an independent fix; grouped here as they touch the same loop/branch machinery. All land on top of `main`; full suite green.

**Commits (oldest → newest):**

- **Fix structurizing loops with sequential branches sharing a condition.** KA splits a loop body at each `@synchronize` and wraps each segment in `if cond`, so a loop body gets multiple sequential `if cond` diamonds sharing the condition (the later ones updating an escaping loop-carried accumulator). `walk.jl` pass-through-merge absorption is now gated on a single successor (a 2-successor merge is itself a branch, previously swallowed → "SSA used but not defined"); `structurize.jl` widens types to concrete `Type`s (a masking-if merge phi whose only defined edge is a literal was typed `Core.Const(lit)`, illegal as an scf result/blockarg).

- **Structurize short-circuit-guarded bodies via an MLIR edge multiplexer** (`if a||b { body }`, `&&`, value forms) — the body is reached from both arms, so it lands in neither then/else region.

- **Fix `UndefRefError` on an undef phi slot in `find_gated_body`** (`enumerate(phi.values)` over undef phi slots).

- **Thread PiNode-referenced loop values out as exit values.** `find_extra_exit_values`/`stmt_ssa_uses` didn't handle `PiNode`, so a post-loop `PiNode(%v, T)` use was invisible and `%v` was never threaded out → cross-region SSA (MLIR dominance error).

- **Count the `:invoke` callee (`args[2]`) as a use** (the original #48 fix) — or DCE drops the callee definition.

- **Preserve a throw inside a loop instead of dropping it to a bare break.** A `throw` inside a loop exits to a dead-end block (no successors, terminal `Union{}`); it's never in the natural loop body, so the loop walk collapsed the edge to a bare `BreakOp` *without emitting the block's statements* — the throw was silently discarded (the function returned normally on input that should have thrown). Fix: at both `BreakOp`-collapse sites, detect a dead-end throw/unreachable exit (`is_throw_exit`) and emit its statements + `unreachable` (`ReturnNode()`), matching the proven out-of-loop throw path. Gated so normal loop exits still become breaks.

Each fix has a regression test in `test/structurize.jl` / `test/ir.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)