### PR TITLE
One explicit-edge representation, lifted directly to structured IR

### DIFF
--- a/src/IRStructurizer.jl
+++ b/src/IRStructurizer.jl
@@ -5,8 +5,7 @@ using Core: MethodInstance, CodeInfo, SSAValue, Argument, SlotNumber,
 
 using Core.Compiler: IRCode, CFG, BasicBlock, InstructionStream, StmtRange,
                      construct_domtree, DomTree, dominates,
-                     construct_postdomtree, PostDomTree, postdominates,
-                     CFGReachability, bb_in_irreducible_loop,
+                     CFGReachability,
                      widenconst,
                      WorldRange
 using Base: code_ircode
@@ -14,6 +13,10 @@ using Base: code_ircode
 # structured IR definitions
 include("ir/types.jl")
 include("ir/show.jl")
+
+# explicit-edge mutable CFG types (MBlock/MCFG) — defined before the lift so its
+# StructurizeCtx and method signatures can name them; operations live in multiplex.jl
+include("structurize/mcfg.jl")
 
 # substitution machinery (phi refs → block args)
 include("structurize/substitutions.jl")

--- a/src/ir/types.jl
+++ b/src/ir/types.jl
@@ -666,24 +666,28 @@ validates that no unstructured control flow remains.
 """
 function StructuredIRCode(ir::IRCode; structurize::Bool=true, validate::Bool=true,
                           promote::Bool=true)
-    # Mutate-then-lift: collapse every multi-entry CFG situation (irreducible
-    # loop headers; multi-predecessor continuations) to single-entry with edge
-    # multiplexers *before* capturing debug info, so all downstream views use the
-    # normalized IR. A no-op (returns `ir` untouched) for already-reducible CFGs.
+    # Mutate-then-lift: collapse every multi-entry CFG situation (irreducible loop
+    # headers, multi-exit loops, multi-predecessor continuations) to single-entry
+    # with edge multiplexers, then lift the resulting `MCFG` directly (block args +
+    # per-edge operands replace phi nodes) — no dense round-trip. `lift_mcfg`
+    # captures debug info from the `MBlock` codelocs and runs the structurize walk.
     if structurize && !isempty(ir.stmts.stmt)
-        ir = normalize_cf(ir)
+        return lift_mcfg(normalize_cf(ir); validate, promote)
     end
+
+    # Flat view (structurize=false, or empty IR): the raw IRCode statements in a
+    # single block, no normalization. Negative line_map = direct PC ref.
     argtypes = copy(ir.argtypes)
     sptypes = copy(ir.sptypes)
+    @static if VERSION >= v"1.12-"
+        valid_worlds = ir.valid_worlds
+    else
+        valid_worlds = WorldRange(typemin(UInt), typemax(UInt))
+    end
     stmts = ir.stmts.stmt
     types = ir.stmts.type
-    # Per-statement IR_FLAG_* bitmask (see Compiler/src/optimize.jl). Inference
-    # and the inliner populate this with effect-freeness, nothrow, etc.; we
-    # carry it through so SCI passes can consult effects without re-deriving.
-    flags = ir.stmts.flag
+    flags = ir.stmts.flag      # per-statement IR_FLAG_* bitmask (effects, nothrow, …)
     n = length(stmts)
-
-    # Capture debug info: negative values = direct reference into table
     @static if VERSION >= v"1.12-"
         debuginfo_table = ir.debuginfo
         line_map = Dict{Int, Int}()
@@ -698,8 +702,6 @@ function StructuredIRCode(ir::IRCode; structurize::Bool=true, validate::Bool=tru
             li != 0 && (line_map[i] = -li)  # linetable index
         end
     end
-
-    # Build flat entry block
     entry = Block()
     for i in 1:n
         stmt = stmts[i]
@@ -709,35 +711,10 @@ function StructuredIRCode(ir::IRCode; structurize::Bool=true, validate::Bool=tru
             push!(entry, i, stmt, types[i], flags[i])
         end
     end
-
-    # Carry the IR's world-age range (1.12+; 1.11 doesn't have the field
-    # and also doesn't enforce binding-access world warnings, so the
-    # unbounded default is fine).
-    @static if VERSION >= v"1.12-"
-        valid_worlds = ir.valid_worlds
-    else
-        valid_worlds = WorldRange(typemin(UInt), typemax(UInt))
-    end
-
     sci = StructuredIRCode(argtypes, sptypes, entry, n, 0,
                            debuginfo_table, line_map, valid_worlds)
-
-    if structurize && n > 0
-        entry, max_ssa, max_arg, updated_line_map =
-            IRStructurizer.structurize(ir, line_map; promote)
-        sci.entry = entry
-        sci.max_ssa_idx = max_ssa
-        sci.max_arg_idx = max_arg
-        # line_map was mutated in-place by structurize, but merge any extras
-        merge!(sci.line_map, updated_line_map)
-    end
-
-    # Set parent chain: entry → SCI, sub-blocks → containing block.
-    # Must be done after structurize+promote since promote_loops! replaces
-    # block.body without going through push! (which normally sets parents).
     sci.entry.parent = sci
     fix_parents!(sci.entry)
-
     if validate
         validate_scf(sci.entry)
         validate_no_phis(sci.entry)
@@ -745,7 +722,6 @@ function StructuredIRCode(ir::IRCode; structurize::Bool=true, validate::Bool=tru
         validate_ssa_defs(sci)
         validate_ssa_uniqueness(sci)
     end
-
     return sci
 end
 

--- a/src/structurize.jl
+++ b/src/structurize.jl
@@ -12,29 +12,44 @@
 =============================================================================#
 
 mutable struct StructurizeCtx
-    ir::IRCode
+    m::Any                       # the MCFG (untyped: MCFG is defined in multiplex.jl,
+                                 # included after this file; annotate `ctx.m::MCFG` locally)
+    cfg::CFG                     # build_cfg(m), cached (block index == MBlock id)
     domtree::DomTree
-    postdomtree::PostDomTree
     # header → set of block indices in the natural loop
     loop_map::Dict{Int, Set{Int}}
     next_ssa::Int
     next_arg::Int
-    types::Vector{Any}
+    types::Dict{Int, Any}       # ssa id → widened type (block args + body stmts + synthesized)
+    def_block::Dict{Int, Int}   # ssa id → defining MBlock id (block args + body stmts)
     ssa_remap::Dict{Int, Int}   # original → fresh (for inner defs)
     line_map::Dict{Int, Int}    # ssa_idx → anchor PC/linetable index
 end
 
-function StructurizeCtx(ir::IRCode, line_map::Dict{Int, Int}=Dict{Int, Int}())
-    domtree = construct_domtree(ir)
-    postdomtree = construct_postdomtree(ir)
-    loops = compute_natural_loops(ir, domtree)
-    n = length(ir.stmts.stmt)
-    # `ctx.types` feeds only structural positions (op result / block-arg / Undef
-    # types), which must be concrete `Type`s. Widen so a lattice element (e.g.
-    # `Core.Const` on a phi with one literal edge) can't land there; statement
-    # types copied verbatim by the walk keep their original `ir.stmts.type`.
-    types = Any[widenconst(t) for t in ir.stmts.type]
-    StructurizeCtx(ir, domtree, postdomtree, loops, n + 1, 1, types, Dict{Int,Int}(), line_map)
+function StructurizeCtx(m, line_map::Dict{Int, Int}=Dict{Int, Int}())
+    cfg = build_cfg(m)
+    domtree = construct_domtree(cfg)
+    loops = natural_loops_m(m)
+    # `ctx.types` feeds structural positions (op result / block-arg / Undef types),
+    # which must be concrete `Type`s. Widen so a lattice element (e.g. `Core.Const`
+    # on a single-literal-edge arg) can't land there. Block-arg / synthesized types
+    # live in `m.types`; body-statement types live in each `MStmt`.
+    types = Dict{Int, Any}()
+    def_block = Dict{Int, Int}()
+    for (id, t) in m.types
+        types[id] = widenconst(t)
+    end
+    for (bid, b) in enumerate(m.blocks)
+        for a in b.args
+            def_block[a] = bid
+        end
+        for s in b.body
+            types[s.id] = widenconst(s.type)
+            def_block[s.id] = bid
+        end
+    end
+    StructurizeCtx(m, cfg, domtree, loops, m.next_id, 1, types, def_block,
+                   Dict{Int,Int}(), line_map)
 end
 
 alloc_ssa!(ctx::StructurizeCtx) = (idx = ctx.next_ssa; ctx.next_ssa += 1; idx)
@@ -100,20 +115,22 @@ include("structurize/loops.jl")
 =============================================================================#
 
 """
-    structurize(ir::IRCode, line_map; promote=true) -> (Block, max_ssa, max_arg, line_map)
+    structurize(m::MCFG, line_map; promote=true) -> (Block, max_ssa, max_arg, line_map)
 
-Convert flat IRCode into a structured Block with nested IfOp/LoopOp/WhileOp/ForOp.
+Convert the (already-normalized) explicit-edge `MCFG` into a structured Block with
+nested IfOp/LoopOp/WhileOp/ForOp. The lift reads the `MBlock` form directly — block
+arguments + per-edge operands replace Julia phi nodes — so there is no dense
+round-trip.
 
 The core walk emits only the generic `LoopOp` (invariant I6); `WhileOp`/`ForOp`
 recognition lives entirely in the `promote_loops!` post-pass. Pass `promote=false`
 to get the pre-promotion form (every loop is a `LoopOp`) — used to test I6.
 """
-function structurize(ir::IRCode, line_map::Dict{Int, Int}=Dict{Int, Int}();
+function structurize(m, line_map::Dict{Int, Int}=Dict{Int, Int}();
                      promote::Bool=true)
-    check_irreducible(ir)
-    ctx = StructurizeCtx(ir, line_map)
-    all_blocks = Set(1:length(ir.cfg.blocks))
-    entry = structurize_region!(ctx, 1, all_blocks)
+    ctx = StructurizeCtx(m, line_map)
+    all_blocks = Set(1:length(ctx.m.blocks))
+    entry = structurize_region!(ctx, ctx.m.entry, all_blocks)
     promote && promote_loops!(entry, ctx)
     return entry, ctx.next_ssa - 1, ctx.next_arg - 1, ctx.line_map
 end

--- a/src/structurize/cfg.jl
+++ b/src/structurize/cfg.jl
@@ -1,35 +1,12 @@
 #=============================================================================
- Natural Loop Detection
+ Natural loop lookup
+
+ Natural loops are detected on the MBlock CFG by `natural_loops_m` (multiplex.jl)
+ and cached in `ctx.loop_map` (header id → in-loop block ids). Irreducible
+ (multi-entry) loops are normalized away upstream by `normalize_cf!` (an entry
+ multiplexer collapses each to a single-entry loop), so the lift only ever sees
+ reducible, single-entry loops.
 =============================================================================#
-
-"""
-    compute_natural_loops(ir, domtree) -> Dict{Int, Set{Int}}
-
-Find all natural loops via backedge detection. A backedge src→header (where
-header dominates src) defines a natural loop: header + all blocks that can
-reach src without going through header.
-"""
-function compute_natural_loops(ir::IRCode, domtree::DomTree)
-    loops = Dict{Int, Set{Int}}()
-    for (i, bb) in enumerate(ir.cfg.blocks)
-        for succ in bb.succs
-            dominates(domtree, succ, i) || continue
-            header = succ
-            body = get!(Set{Int}, loops, header)
-            push!(body, header)
-            worklist = Int[i]
-            while !isempty(worklist)
-                b = pop!(worklist)
-                b ∈ body && continue
-                push!(body, b)
-                for pred in ir.cfg.blocks[b].preds
-                    pred ∉ body && push!(worklist, pred)
-                end
-            end
-        end
-    end
-    loops
-end
 
 """Return the innermost loop at `header` that is contained within `region_blocks`, or nothing."""
 function get_loop_at(ctx::StructurizeCtx, header::Int, region_blocks::Set{Int})
@@ -38,30 +15,4 @@ function get_loop_at(ctx::StructurizeCtx, header::Int, region_blocks::Set{Int})
     # Only consider loops fully contained in the region
     issubset(body, region_blocks) || return nothing
     return body
-end
-
-#=============================================================================
- Irreducible CFG Detection
-=============================================================================#
-
-"""
-    check_irreducible(ir::IRCode)
-
-Backstop assertion that the IR is reducible by the time the lift runs. Irreducible
-(multi-entry) SCCs — from `@goto` — are normalized away upstream by `normalize_cf`
-(an entry multiplexer collapses each to a single-entry loop). This should
-therefore never fire; if it does, normalization failed to apply, and throwing
-`UnstructuredControlFlowError` is far better than letting the recursive walk spin
-on a multi-entry cycle.
-"""
-function check_irreducible(ir::IRCode)
-    domtree = construct_domtree(ir)
-    reach = CFGReachability(ir.cfg, domtree)
-    for bb in 1:length(ir.cfg.blocks)
-        if bb_in_irreducible_loop(reach, bb)
-            throw(UnstructuredControlFlowError(
-                "irreducible control flow remains at BB$bb after normalization — " *
-                "this is an internal error in normalize_cf (the entry multiplexer)"))
-        end
-    end
 end

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -160,33 +160,28 @@ function collect_dominated!(result::Set{Int}, domtree::DomTree, root::Int, regio
 end
 
 #=============================================================================
- Merge Phi Extraction (block args + per-edge operands)
+ Merge result shape (block args + per-edge operands)
 =============================================================================#
 
-"""Extract the block arguments at `merge_idx` as [`MergePhiInfo`](@ref): each
-argument's stable id plus the per-predecessor operand feeding it (the operand on
-edge `pred → merge`). An `Undef` operand is an unassigned phi slot (omitted), so a
-predecessor on a dead path contributes nothing. The MBlock analogue of reading
-the merge block's leading phi nodes."""
-function extract_merge_phis(ctx::StructurizeCtx, merge_idx::Int, region_blocks::Set{Int})
+"""Read the merge block `merge_idx`'s block arguments as a [`MergeInfo`](@ref): the
+*live* arg positions — those some predecessor edge assigns a real (non-`Undef`)
+operand — become the `IfOp`'s results. An arg every predecessor leaves `Undef` is a
+dead phi slot and is dropped (no result). Returns `nothing` if no arg is live. The
+MBlock analogue of reading a merge block's leading phi nodes, but recording only
+the result *shape*: each arm later yields its own edge's operands directly
+(`yield_to_merge!`), so there is no per-predecessor value map here."""
+function merge_info(ctx::StructurizeCtx, merge_idx::Int)
     m = ctx.m::MCFG
-    result = MergePhiInfo[]
-    1 <= merge_idx <= length(m.blocks) || return result
+    1 <= merge_idx <= length(m.blocks) || return nothing
     args = m.blocks[merge_idx].args
-    isempty(args) && return result
+    isempty(args) && return nothing
     preds = ctx.cfg.blocks[merge_idx].preds
+    positions = Int[]; ids = Int[]; types = Any[]
     for (k, arg) in enumerate(args)
-        edge_values = Dict{Int, Any}()
-        for p in preds
-            ops = edge_operands(m, p, merge_idx)
-            ops === nothing && continue
-            v = ops[k]
-            v isa Undef && continue   # undef edge → unassigned phi slot
-            edge_values[p] = v
-        end
-        !isempty(edge_values) && push!(result, MergePhiInfo(arg, edge_values))
+        any(p -> (o = edge_operands(m, p, merge_idx); o !== nothing && !(o[k] isa Undef)), preds) || continue
+        push!(positions, k); push!(ids, arg); push!(types, get(ctx.types, arg, Any))
     end
-    return result
+    isempty(ids) ? nothing : MergeInfo(merge_idx, positions, ids, types)
 end
 
 #=============================================================================

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -1,9 +1,13 @@
 #=============================================================================
  Branch Region Splitting (dominance-based)
+
+ These analyses read only CFG topology + dominance (`cfg`/`domtree`), so they run
+ unchanged whether the CFG comes from `ir.cfg` or `build_cfg(m)`. The lift passes
+ `ctx.cfg`/`ctx.domtree`; `normalize_one_continuation!` passes a fresh pair.
 =============================================================================#
 
 """
-    find_branch_regions(ctx, current, true_dest, false_dest, region_blocks, loop_ctx)
+    find_branch_regions(cfg, domtree, current, true_dest, false_dest, region_blocks, loop_ctx)
         -> (then_blocks, else_blocks, merge)
 
 Split region_blocks into then/else regions using dominance, and select the merge
@@ -20,12 +24,11 @@ continuation that needs the edge multiplexer), `merge` is `nothing` and the
 caller routes accordingly. Post-dominance never enters as an ordering key, so
 the result depends only on CFG topology + dominance (invariant I1).
 """
-function find_branch_regions(ctx::StructurizeCtx, current::Int,
+function find_branch_regions(cfg::CFG, domtree::DomTree, current::Int,
                               true_dest::Int, false_dest::Int,
                               region_blocks::Set{Int},
                               loop_ctx::Union{Nothing, LoopCtx}=nothing)
-    ir = ctx.ir
-    nblocks = length(ir.cfg.blocks)
+    nblocks = length(cfg.blocks)
 
     then_blocks = Set{Int}()
     else_blocks = Set{Int}()
@@ -35,13 +38,13 @@ function find_branch_regions(ctx::StructurizeCtx, current::Int,
     # NOT a loop backedge to it. Loop backedges don't count because the loop body
     # is structurally inside the branch, not a separate entry path.
     if true_dest ∈ region_blocks && true_dest <= nblocks &&
-       count_non_backedge_preds(ir, ctx, true_dest, region_blocks) == 1
-        collect_dominated!(then_blocks, ctx.domtree, true_dest, region_blocks)
+       count_non_backedge_preds(cfg, domtree, true_dest, region_blocks) == 1
+        collect_dominated!(then_blocks, domtree, true_dest, region_blocks)
     end
 
     if false_dest ∈ region_blocks && false_dest <= nblocks &&
-       count_non_backedge_preds(ir, ctx, false_dest, region_blocks) == 1
-        collect_dominated!(else_blocks, ctx.domtree, false_dest, region_blocks)
+       count_non_backedge_preds(cfg, domtree, false_dest, region_blocks) == 1
+        collect_dominated!(else_blocks, domtree, false_dest, region_blocks)
     end
 
     # Remove any overlap with loop bodies that will be handled separately
@@ -52,7 +55,7 @@ function find_branch_regions(ctx::StructurizeCtx, current::Int,
     # merge is the single distinct target of the edges leaving `current ∪ then ∪
     # else`. A unique target → that's the merge; zero targets → both arms diverge;
     # multiple targets → a multi-entry continuation handled by the multiplexer.
-    entries, _ = branch_continuation(ctx, current, true_dest, false_dest,
+    entries, _ = branch_continuation(cfg, domtree, current, true_dest, false_dest,
                                      then_blocks, else_blocks, region_blocks, loop_ctx)
     merge = length(entries) == 1 ? only(entries) : nothing
 
@@ -60,7 +63,7 @@ function find_branch_regions(ctx::StructurizeCtx, current::Int,
 end
 
 """
-    branch_continuation(ctx, current, true_dest, false_dest, then_blocks,
+    branch_continuation(cfg, domtree, current, true_dest, false_dest, then_blocks,
                          else_blocks, region_blocks)
         -> (continuation_entries::Vector{Int}, notContinuation::Set{Int})
 
@@ -90,13 +93,12 @@ out-of-region targets as entries, but DROP loop boundaries (`loop_ctx`): a
 back-edge to the header is a continue and an edge out of the loop is a break —
 neither is part of this branch's forward continuation.
 """
-function branch_continuation(ctx::StructurizeCtx, current::Int,
+function branch_continuation(cfg::CFG, domtree::DomTree, current::Int,
                               true_dest::Int, false_dest::Int,
                               then_blocks::Set{Int}, else_blocks::Set{Int},
                               region_blocks::Set{Int},
                               loop_ctx::Union{Nothing, LoopCtx}=nothing)
-    ir = ctx.ir
-    nblocks = length(ir.cfg.blocks)
+    nblocks = length(cfg.blocks)
 
     # notContinuation = branch entry ∪ arm regions; continuation = distinct
     # targets of edges leaving it (edge targets, not post-dominance → survives
@@ -114,7 +116,7 @@ function branch_continuation(ctx::StructurizeCtx, current::Int,
     seen = Set{Int}()
     for b in scan
         1 <= b <= nblocks || continue
-        bb = ir.cfg.blocks[b]
+        bb = cfg.blocks[b]
         isempty(bb.succs) && continue   # return-like block: no continuation edge
         for succ in bb.succs
             succ ∈ notContinuation && continue
@@ -123,7 +125,7 @@ function branch_continuation(ctx::StructurizeCtx, current::Int,
                (succ == loop_ctx.header || succ ∉ loop_ctx.loop_blocks)
                 continue
             end
-            dominates(ctx.domtree, succ, b) && continue   # back-edge to enclosing header
+            dominates(domtree, succ, b) && continue   # back-edge to enclosing header
             if succ ∉ seen
                 push!(seen, succ)
                 push!(entries, succ)
@@ -134,12 +136,12 @@ function branch_continuation(ctx::StructurizeCtx, current::Int,
 end
 
 """Count predecessors of `block` in `region` that are not loop backedges to `block`."""
-function count_non_backedge_preds(ir::IRCode, ctx::StructurizeCtx, block::Int, region::Set{Int})
+function count_non_backedge_preds(cfg::CFG, domtree::DomTree, block::Int, region::Set{Int})
     count = 0
-    for pred in ir.cfg.blocks[block].preds
+    for pred in cfg.blocks[block].preds
         pred ∈ region || continue
         # A backedge is an edge where the target dominates the source
-        if dominates(ctx.domtree, block, pred)
+        if dominates(domtree, block, pred)
             continue  # skip loop backedge
         end
         count += 1
@@ -158,28 +160,31 @@ function collect_dominated!(result::Set{Int}, domtree::DomTree, root::Int, regio
 end
 
 #=============================================================================
- Merge Phi Extraction
+ Merge Phi Extraction (block args + per-edge operands)
 =============================================================================#
 
-"""Extract phi nodes at `merge_idx` that have edges from blocks in `region`."""
-function extract_merge_phis(ir::IRCode, merge_idx::Int, region_blocks::Set{Int})
+"""Extract the block arguments at `merge_idx` as [`MergePhiInfo`](@ref): each
+argument's stable id plus the per-predecessor operand feeding it (the operand on
+edge `pred → merge`). An `Undef` operand is an unassigned phi slot (omitted), so a
+predecessor on a dead path contributes nothing. The MBlock analogue of reading
+the merge block's leading phi nodes."""
+function extract_merge_phis(ctx::StructurizeCtx, merge_idx::Int, region_blocks::Set{Int})
+    m = ctx.m::MCFG
     result = MergePhiInfo[]
-    nblocks = length(ir.cfg.blocks)
-    1 <= merge_idx <= nblocks || return result
-
-    bb = ir.cfg.blocks[merge_idx]
-    for si in first(bb.stmts):last(bb.stmts)
-        stmt = ir.stmts.stmt[si]
-        stmt isa PhiNode || continue
-
+    1 <= merge_idx <= length(m.blocks) || return result
+    args = m.blocks[merge_idx].args
+    isempty(args) && return result
+    preds = ctx.cfg.blocks[merge_idx].preds
+    for (k, arg) in enumerate(args)
         edge_values = Dict{Int, Any}()
-        for (edge_idx, edge) in enumerate(stmt.edges)
-            if isassigned(stmt.values, edge_idx)
-                # Include edges from region blocks AND direct predecessors
-                edge_values[Int(edge)] = stmt.values[edge_idx]
-            end
+        for p in preds
+            ops = edge_operands(m, p, merge_idx)
+            ops === nothing && continue
+            v = ops[k]
+            v isa Undef && continue   # undef edge → unassigned phi slot
+            edge_values[p] = v
         end
-        !isempty(edge_values) && push!(result, MergePhiInfo(si, edge_values))
+        !isempty(edge_values) && push!(result, MergePhiInfo(arg, edge_values))
     end
     return result
 end
@@ -224,10 +229,8 @@ Returns the exit destination block (may be outside region_blocks).
 """
 function emit_loop!(block::Block, ctx::StructurizeCtx, header::Int,
                      loop_blocks::Set{Int}, region_blocks::Set{Int})
-    ir = ctx.ir
-
-    # 1. Extract header phi nodes
-    phi_info = extract_loop_phis(ir, header, loop_blocks)
+    # 1. Header block arguments (the loop's phis), as entry/carried value pairs.
+    phi_info = extract_loop_phis(ctx, header, loop_blocks)
 
     # 2. The loop's single exit — its one non-loop successor. The single-exiting
     #    latch (normalize_cf) unified every multi-exit loop to one exit edge, so
@@ -240,7 +243,7 @@ function emit_loop!(block::Block, ctx::StructurizeCtx, header::Int,
     #    so this is a flat used-outside scan — no post-loop BFS, no remap-vs-merge
     #    collision (the old `find_extra_exit_values`).
     already_exported = Set{Int}(p.ssa_idx for p in phi_info)
-    extra_exits = loop_escaping_values(ir, loop_blocks, already_exported)
+    extra_exits = loop_escaping_values(ctx, loop_blocks, already_exported)
 
     # 4. Build init/carried values and block arguments
     init_values = IRValue[]
@@ -274,7 +277,7 @@ function emit_loop!(block::Block, ctx::StructurizeCtx, header::Int,
         fresh = alloc_ssa!(ctx)
         ctx.ssa_remap[ex.ssa_idx] = fresh
         anchor_line!(ctx, fresh, ex.ssa_idx)
-        # `ex.type` bypasses `ctx.types`, so widen it here too.
+        # `ex.type` is already widened (`ctx.types`), but stay robust.
         ext = widenconst(ex.type)
         push!(init_values, Undef(ext))
         push!(carried_values, SSAValue(fresh))  # carry the fresh-index value
@@ -304,9 +307,8 @@ function emit_loop!(block::Block, ctx::StructurizeCtx, header::Int,
     # 6. Apply phi→arg substitutions
     apply_substitutions!(body, subs, ctx)
 
-    # 7. Emit LoopOp + getfields
-    # Anchor debug info to the loop header's first statement
-    header_anchor = first(ir.cfg.blocks[header].stmts)
+    # 7. Emit LoopOp + getfields. Anchor debug info to the header's first stmt.
+    header_anchor = first_body_id(ctx, header)
 
     loop_op = LoopOp(body, init_values)
     loop_ssa = alloc_ssa!(ctx)
@@ -373,33 +375,34 @@ struct LoopPhiInfo
     carried_val::Any
 end
 
-"""Extract phi nodes from a loop header, separating entry and carried values."""
-function extract_loop_phis(ir::IRCode, header::Int, loop_blocks::Set{Int})
+"""Extract a loop header's block arguments, separating each into its entry value
+(operand on an edge from outside the loop) and carried value (operand on the back
+edge from inside the loop). The single-exiting latch / entry mux guarantee one of
+each, so an argument with only one side is malformed (a dead edge the optimizer
+left, or unexpected loop structure) — error rather than emit wrong carries."""
+function extract_loop_phis(ctx::StructurizeCtx, header::Int, loop_blocks::Set{Int})
+    m = ctx.m::MCFG
     result = LoopPhiInfo[]
-    bb = ir.cfg.blocks[header]
-    for si in first(bb.stmts):last(bb.stmts)
-        stmt = ir.stmts.stmt[si]
-        stmt isa PhiNode || continue
+    preds = ctx.cfg.blocks[header].preds
+    for (k, arg) in enumerate(m.blocks[header].args)
         entry_val = nothing
         carried_val = nothing
-        for (edge_idx, edge) in enumerate(stmt.edges)
-            isassigned(stmt.values, edge_idx) || continue
-            val = stmt.values[edge_idx]
-            if Int(edge) ∈ loop_blocks
-                carried_val = val
+        for p in preds
+            ops = edge_operands(m, p, header)
+            ops === nothing && continue
+            v = ops[k]
+            v isa Undef && continue
+            if p ∈ loop_blocks
+                carried_val = v
             else
-                entry_val = val
+                entry_val = v
             end
         end
         if entry_val !== nothing && carried_val !== nothing
-            push!(result, LoopPhiInfo(si, entry_val, carried_val))
+            push!(result, LoopPhiInfo(arg, entry_val, carried_val))
         elseif entry_val !== nothing || carried_val !== nothing
-            # A phi with edges from only one side of the loop boundary is
-            # malformed — the optimizer may have removed a dead edge, or
-            # the loop has unusual structure. Error rather than silently
-            # producing wrong loop-carried values.
             has_entry = entry_val !== nothing
-            error("internal error: loop header phi %$si at BB$header has ",
+            error("internal error: loop header arg %$arg at BB$header has ",
                   has_entry ? "entry" : "carried", " value but no ",
                   has_entry ? "carried" : "entry", " value")
         end
@@ -413,7 +416,7 @@ latch (`normalize_cf`) unifies every multi-exit loop to one exit edge, so this i
 unambiguous — no post-dominance preference, no block-index tie-break (the old
 `find_loop_exit` I1 leak). More than one would mean the latch failed to fire."""
 function single_loop_exit(ctx::StructurizeCtx, loop_blocks::Set{Int})
-    exits = find_loop_exits(ctx.ir, loop_blocks)
+    exits = find_loop_exits(ctx, loop_blocks)
     isempty(exits) && return nothing
     length(exits) == 1 && return only(exits)
     error("internal error: loop has ", length(exits), " exit edges; the single-",
@@ -421,10 +424,10 @@ function single_loop_exit(ctx::StructurizeCtx, loop_blocks::Set{Int})
 end
 
 """Find all blocks outside `loop_blocks` that are successors of loop blocks."""
-function find_loop_exits(ir::IRCode, loop_blocks::Set{Int})
+function find_loop_exits(ctx::StructurizeCtx, loop_blocks::Set{Int})
     exits = Set{Int}()
     for b in loop_blocks
-        for succ in ir.cfg.blocks[b].succs
+        for succ in ctx.cfg.blocks[b].succs
             succ ∉ loop_blocks && push!(exits, succ)
         end
     end
@@ -432,65 +435,57 @@ function find_loop_exits(ir::IRCode, loop_blocks::Set{Int})
 end
 
 """
-Loop-internal SSA values referenced from outside the loop — a flat used-outside
-scan over every non-loop block (deterministic block/statement order).
+Loop-internal SSA values referenced from outside the loop, threaded out as loop
+results. A value escapes when it is used at a position *not strictly inside* the
+loop, classified by where the operand is consumed:
 
-After the single-exiting latch + reduce form (`normalize_cf`), every loop-internal
-value read downstream is a latch block argument, so the escapees are exactly the
-values some non-loop block uses whose definition is in the loop. No post-loop BFS
-from a chosen "primary" exit (the old `find_extra_exit_values`, which missed
-values read on a sibling/inner path), and no remap-vs-merge-phi collision: each is
-threaded out once as a loop result. `already_exported` skips the header phis,
-which are already loop-carried.
+- a body statement / terminator operand of a **non-loop** block, or
+- an **edge operand on an edge whose target is non-loop** — a value carried out of
+  the loop into a successor's block argument (the MBlock form of the old "exit
+  phi": the loop-exit edge's operand lives on the *in-loop* latch, but it feeds a
+  *non-loop* block's arg, so it escapes).
+
+Deterministic block/operand order; `already_exported` skips the header phis (which
+are already loop-carried). Over-approximation is impossible — every reported value
+genuinely has an outside use — and `promote_loops!` drops any that the LoopOp
+doesn't need.
 """
-function loop_escaping_values(ir::IRCode, loop_blocks::Set{Int},
+function loop_escaping_values(ctx::StructurizeCtx, loop_blocks::Set{Int},
                               already_exported::Set{Int})
+    m = ctx.m::MCFG
     result = @NamedTuple{ssa_idx::Int, type::Any}[]
     seen = Set{Int}()
-    for b in 1:length(ir.cfg.blocks)
-        b ∈ loop_blocks && continue
-        bb = ir.cfg.blocks[b]
-        for si in first(bb.stmts):last(bb.stmts)
-            for u in stmt_ssa_uses(ir.stmts.stmt[si])
-                is_defined_in(u, loop_blocks, ir) || continue
-                (u.id ∈ already_exported || u.id ∈ seen) && continue
-                push!(result, (; ssa_idx=u.id, type=ir.stmts.type[u.id]))
-                push!(seen, u.id)
+    function consider(@nospecialize(v))
+        v isa SSAValue || return
+        id = v.id
+        (get(ctx.def_block, id, 0) ∈ loop_blocks) || return
+        (id ∈ already_exported || id ∈ seen) && return
+        push!(result, (; ssa_idx=id, type=get(ctx.types, id, Any)))
+        push!(seen, id)
+    end
+    for (bid, b) in enumerate(m.blocks)
+        # Body + terminator operands escape only from a non-loop block.
+        if bid ∉ loop_blocks
+            for s in b.body
+                remap_ssa(s.stmt, v -> (consider(v); v))
+            end
+            t = b.term
+            if t isa MCondBr
+                consider(t.cond)
+            elseif t isa MReturn
+                t.has_val && consider(t.val)
+            end
+        end
+        # An edge operand escapes when the edge leaves the loop (target ∉ loop):
+        # a loop-internal value carried into the non-loop successor's block args.
+        t = b.term
+        edges = t isa MGoto ? (t.edge,) : t isa MCondBr ? (t.t, t.f) : ()
+        for e in edges
+            e.target ∈ loop_blocks && continue
+            for v in e.args
+                consider(v)
             end
         end
     end
     result
 end
-
-"""All `SSAValue` operands referenced by `stmt`: `Expr` args, `GotoIfNot` cond,
-`ReturnNode`/`PiNode` value, a bare `SSAValue`, and the assigned values of a
-`PhiNode` (a non-loop block's phi can carry a loop value out on a loop edge)."""
-function stmt_ssa_uses(@nospecialize(stmt))
-    if stmt isa SSAValue
-        return (stmt,)
-    elseif stmt isa Expr
-        return Iterators.filter(x -> x isa SSAValue, stmt.args)
-    elseif stmt isa GotoIfNot && stmt.cond isa SSAValue
-        return (stmt.cond,)
-    elseif stmt isa ReturnNode && isdefined(stmt, :val) && stmt.val isa SSAValue
-        return (stmt.val,)
-    elseif stmt isa PiNode && stmt.val isa SSAValue
-        # A `PiNode`'s refined value is a real use — without this, a post-loop
-        # type-assertion on a loop-internal SSA isn't threaded out as an exit.
-        return (stmt.val,)
-    elseif stmt isa PhiNode
-        return (stmt.values[k] for k in eachindex(stmt.values)
-                if isassigned(stmt.values, k) && stmt.values[k] isa SSAValue)
-    else
-        return ()
-    end
-end
-
-function is_defined_in(val::SSAValue, blocks::Set{Int}, ir::IRCode)
-    for blk_idx in blocks
-        bb = ir.cfg.blocks[blk_idx]
-        val.id in first(bb.stmts):last(bb.stmts) && return true
-    end
-    false
-end
-is_defined_in(val, blocks, ir) = false

--- a/src/structurize/loops.jl
+++ b/src/structurize/loops.jl
@@ -254,13 +254,13 @@ function emit_loop!(block::Block, ctx::StructurizeCtx, header::Int,
     subs = Dict{Int, BlockArgument}()
 
     for phi in phi_info
-        # If a preceding IfOp already defined this phi SSA (via getfield),
-        # use that as init_val — it captures the correct branch-selected value.
-        # Otherwise the entry value, remapped through `ssa_remap`: a single-edge
-        # phi feeding this loop's entry was renamed (not emitted at its own index),
-        # so the raw `entry_val` would be an undefined SSA.
-        init_val = haskey(block.body, phi.ssa_idx) ? SSAValue(phi.ssa_idx) :
-                   remap_ssa_ref(phi.entry_val, ctx.ssa_remap)
+        # The entry value comes through the pre-header: a header is single-entry
+        # from outside (`normalize_one_preheader!`), so its one entry edge carries
+        # the merged init (a branch selection / irreducible discriminator computed
+        # by the IfOp that yields into the pre-header). Remap through `ssa_remap`
+        # (a single-edge pre-header arg may have been renamed, not emitted at its
+        # own index).
+        init_val = remap_ssa_ref(phi.entry_val, ctx.ssa_remap)
         push!(init_values, init_val)
         push!(carried_values, phi.carried_val)
         push!(phi_indices, phi.ssa_idx)
@@ -317,13 +317,11 @@ function emit_loop!(block::Block, ctx::StructurizeCtx, header::Int,
     anchor_line!(ctx, loop_ssa, header_anchor)
 
     for (i, (phi_idx, phi_type)) in enumerate(zip(phi_indices, phi_types))
-        # If a preceding IfOp already defined this phi SSA (multi-entry header),
-        # use a fresh index for the loop's getfield to avoid SSA uniqueness violation.
-        # Downstream code references phi_idx which is the IfOp's definition;
-        # the loop result is accessed via the fresh index (only used if phi changes in loop).
-        idx = haskey(block.body, phi_idx) ? alloc_ssa!(ctx) : phi_idx
-        push!(block, idx, Expr(:call, Core.getfield, SSAValue(loop_ssa), i), phi_type)
-        idx != phi_idx && anchor_line!(ctx, idx, header_anchor)
+        # The loop result lands at the header arg's own id: a header is never a
+        # branch merge (the pre-header is), so `phi_idx` is not pre-defined by an
+        # enclosing IfOp — no fresh-index dance, and post-loop uses of `phi_idx`
+        # resolve to this result (ISSUES.md #2 fixed).
+        push!(block, phi_idx, Expr(:call, Core.getfield, SSAValue(loop_ssa), i), phi_type)
     end
 
     return exit_dest

--- a/src/structurize/mcfg.jl
+++ b/src/structurize/mcfg.jl
@@ -1,0 +1,77 @@
+# The explicit-edge mutable CFG (`MBlock`/`MCFG`) — MLIR's block-argument /
+# per-edge-operand IR shape, the single working form for the whole structurizer.
+#
+# Julia's `IRCode` is dense (SSA value == position) and fallthrough-sensitive
+# (`GotoIfNot` falls through to the next block on `true`), so it cannot be mutated
+# in place. The `MCFG` carries *stable ids* through CFG mutation (irreducible /
+# multi-exit-loop / continuation normalization, see `multiplex.jl`) and is then
+# lifted to the structured IR directly — block arguments + per-edge operands stand
+# in for SSA phi nodes, so redirecting an edge is local. `ingest` (IRCode → MCFG)
+# is the only conversion in the production pipeline; the lift reads this form.
+#
+# These type definitions live here (rather than in `multiplex.jl`) so the lift's
+# `StructurizeCtx` and the walk's `::MReturn`/`::MCondBr` method signatures, which
+# are defined before `multiplex.jl` is included, can name the types.
+
+"""An edge to a target block, carrying the operands for the target's block
+arguments (one per arg, in order). Operands are `SSAValue`/`Argument`/constant/
+`Undef`. `Undef` marks an unassigned phi slot (a dead/undef predecessor path)."""
+mutable struct MEdge
+    target::Int            # MBlock id
+    args::Vector{Any}      # successor operands, parallel to target's block args
+end
+MEdge(target::Int) = MEdge(target, Any[])
+
+# Terminators with explicit edges (no fallthrough reliance).
+struct MGoto;   edge::MEdge;                       end
+struct MCondBr; cond::Any; t::MEdge; f::MEdge;      end   # GotoIfNot: true=t, false=f
+struct MReturn; val::Any; has_val::Bool;           end    # ReturnNode(val) / ReturnNode()
+const MTerm = Union{MGoto, MCondBr, MReturn}
+
+MReturn() = MReturn(nothing, false)        # unreachable / throw dead-end
+
+"""A statement in a block body: stable id, statement, type, debug codeloc, and
+the `IR_FLAG_*` bitmask carried over from the source IRCode."""
+struct MStmt
+    id::Int
+    stmt::Any
+    type::Any
+    codeloc::NTuple{3, Int32}
+    flag::UInt32
+end
+
+"""A basic block in explicit-edge form: block arguments (the SSA ids that were
+phi nodes), body statements, and a terminator with explicit edges.
+`term_codeloc` is the debug location to attach to the emitted terminator."""
+mutable struct MBlock
+    args::Vector{Int}      # stable ids of block arguments (were phi results)
+    body::Vector{MStmt}
+    term::MTerm
+    term_codeloc::NTuple{3, Int32}
+end
+MBlock() = MBlock(Int[], MStmt[], MReturn(), (Int32(0), Int32(0), Int32(0)))
+
+"""The whole mutable CFG. Blocks are indexed by id == position in `blocks`; the
+vector only ever grows (mux/trampoline blocks appended), so ids are stable.
+`types`/`codelocs` cover block-argument and synthesized ids; body-statement
+types/codelocs live in the `MStmt`s."""
+mutable struct MCFG
+    blocks::Vector{MBlock}
+    entry::Int
+    types::Dict{Int, Any}              # id → type (block args + synthesized stmts)
+    codelocs::Dict{Int, NTuple{3, Int32}}  # id → codeloc (block args + synthesized)
+    next_id::Int                       # next fresh stable id
+    # carried through to the lift / SCI
+    argtypes::Vector{Any}
+    sptypes::Vector{Any}
+    debuginfo::Any
+    valid_worlds::Any
+end
+
+alloc_id!(m::MCFG) = (id = m.next_id; m.next_id += 1; id)
+
+"""Append a new block, returning its id (== its position; the vector only grows)."""
+function add_block!(m::MCFG, b::MBlock)
+    push!(m.blocks, b)
+    return length(m.blocks)
+end

--- a/src/structurize/multiplex.jl
+++ b/src/structurize/multiplex.jl
@@ -774,17 +774,61 @@ function normalize_one_continuation!(m::MCFG)
     return false
 end
 
+#=============================================================================
+ Loop pre-header.
+
+ A loop header reached by more than one entry edge (an `if/else` before the loop,
+ or the absorbed entry-dispatch of an irreducible loop) is *also* a branch merge.
+ Route those entry edges through one pre-header so the header gains a single
+ non-back predecessor — MLIR's `newLoopParentBlock` (`CFGToSCF.cpp:854`), built
+ here in the mutate phase rather than during the lift.
+=============================================================================#
+
+"""Find one loop header with ≥2 entry edges and route them through a single
+pre-header, leaving the back edge on the header. MLIR fires its entry mux on
+`entryEdges.size() > 1` (`CFGToSCF.cpp:821`, per-edge), covering a reducible
+header with several outside predecessors as well as an irreducible one.
+
+Making the header single-entry-from-outside is what lets the lift treat the
+branch's continuation as the *pre-header* (whose args receive the merged entry
+values — an `if`/`else` selection, or an irreducible discriminator — and feed the
+loop init) while the loop *results* stay on the header's own args. Keeping the two
+distinct is what removes the lift's "merge that is a loop header" special case and
+fixes the entry-value-returned-as-result miscompile (ISSUES.md #2).
+
+`absorb=false`, entry edges only: the pre-header forwards into the header's
+existing args, and the single-exiting latch still owns back/exit unification
+(RESEARCH_ANSWER_3 §C4 — no collision). Runs after irreducible + latch so it sees
+the final (mux) header."""
+function normalize_one_preheader!(m::MCFG)
+    loops = natural_loops_m(m)
+    cfg = build_cfg(m)
+    for h in sort!(collect(keys(loops)))
+        body = loops[h]
+        entry_refs = EdgeRef[]
+        for p in sort!(collect(cfg.blocks[h].preds))
+            p ∈ body && continue                      # back edge stays on the header
+            append!(entry_refs, edge_refs(m, p, h))
+        end
+        length(entry_refs) > 1 || continue
+        single_entry_mux!(m, entry_refs)              # absorb=false: a pure pre-header
+        return true
+    end
+    return false
+end
+
 """Mutate `m` until no multi-entry situation remains. Each step collapses one
 multi-entry header (irreducible), one multi-exit loop (the single-exiting latch +
-reduce form), or one multi-predecessor branch continuation — all strictly reduce
-the remaining count (the mux block is single-entry by construction), so this
-terminates. The lift then only ever structurizes single-entry regions."""
+reduce form), one multi-predecessor branch continuation, or one multi-entry loop
+header (the pre-header) — all strictly reduce the remaining count (the mux block is
+single-entry by construction), so this terminates. The lift then only ever
+structurizes single-entry regions."""
 function normalize_cf!(m::MCFG)
     changed = false
     guard = 0
     limit = length(m.blocks) + 16
     while normalize_one_irreducible!(m) || normalize_one_loop_latch!(m) ||
-          normalize_one_continuation!(m)
+          normalize_one_continuation!(m) || normalize_one_preheader!(m)
         changed = true
         guard += 1
         guard > 8 * limit && error("normalize_cf! failed to converge (likely a mux bug)")

--- a/src/structurize/multiplex.jl
+++ b/src/structurize/multiplex.jl
@@ -20,78 +20,10 @@
 # reducible IRCode that the existing lift handles with no new concepts; for N=2
 # the chain is a single `GotoIfNot` → one `IfOp`.
 
-#=============================================================================
- Explicit-edge mutable CFG
-=============================================================================#
-
-"""An edge to a target block, carrying the operands for the target's block
-arguments (one per arg, in order). Operands are `SSAValue`/`Argument`/constant/
-`Undef`. `Undef` becomes an unassigned phi slot at `emit`."""
-mutable struct MEdge
-    target::Int            # MBlock id
-    args::Vector{Any}      # successor operands, parallel to target's block args
-end
-MEdge(target::Int) = MEdge(target, Any[])
-
-# Terminators with explicit edges (no fallthrough reliance).
-struct MGoto;   edge::MEdge;                       end
-struct MCondBr; cond::Any; t::MEdge; f::MEdge;      end   # GotoIfNot: true=t, false=f
-struct MReturn; val::Any; has_val::Bool;           end    # ReturnNode(val) / ReturnNode()
-const MTerm = Union{MGoto, MCondBr, MReturn}
-
-MReturn() = MReturn(nothing, false)        # unreachable / throw dead-end
-
-"""A statement in a block body: stable id, statement, type, debug codeloc, and
-the `IR_FLAG_*` bitmask carried over from the source IRCode."""
-struct MStmt
-    id::Int
-    stmt::Any
-    type::Any
-    codeloc::NTuple{3, Int32}
-    flag::UInt32
-end
-
-"""A basic block in explicit-edge form: block arguments (the SSA ids that were
-phi nodes), body statements, and a terminator with explicit edges.
-`term_codeloc` is the debug location to attach to the emitted terminator."""
-mutable struct MBlock
-    args::Vector{Int}      # stable ids of block arguments (were phi results)
-    body::Vector{MStmt}
-    term::MTerm
-    term_codeloc::NTuple{3, Int32}
-    term_type::Any         # terminator's type; `Union{}` marks an unreachable/throw dead-end
-end
-MBlock() = MBlock(Int[], MStmt[], MReturn(), (Int32(0), Int32(0), Int32(0)), Any)
-
-"""The whole mutable CFG. Blocks are indexed by id == position in `blocks`; the
-vector only ever grows (mux/trampoline blocks appended), so ids are stable.
-`types`/`codelocs` cover block-argument and synthesized ids; body-statement
-types/codelocs live in the `MStmt`s."""
-mutable struct MCFG
-    blocks::Vector{MBlock}
-    entry::Int
-    order::Vector{Int}                 # logical block order (preserved across emit)
-    types::Dict{Int, Any}              # id → type (block args + synthesized stmts)
-    codelocs::Dict{Int, NTuple{3, Int32}}  # id → codeloc (block args + synthesized)
-    flags::Dict{Int, UInt32}           # id → IR_FLAG_* bitmask (block args)
-    next_id::Int                       # next fresh stable id
-    # carried through for emit
-    argtypes::Vector{Any}
-    sptypes::Vector{Any}
-    debuginfo::Any
-    valid_worlds::Any
-end
-
-alloc_id!(m::MCFG) = (id = m.next_id; m.next_id += 1; id)
-
-"""Append a new block, returning its id. Placed last in the logical order unless
-`order=false` (used for fallthrough trampolines, which `emit` places inline)."""
-function add_block!(m::MCFG, b::MBlock; order::Bool=true)
-    push!(m.blocks, b)
-    id = length(m.blocks)
-    order && push!(m.order, id)
-    return id
-end
+# The `MBlock`/`MCFG` type definitions live in `structurize/mcfg.jl` (included
+# before the lift so its method signatures can name them). This file holds the
+# operations: `ingest`/`emit` (the IRCode boundary), the `EdgeMultiplexer`, and
+# the `normalize_cf!` mutate fixpoint.
 
 #=============================================================================
  ingest: IRCode → MCFG  (phi → block-arg + edge-operands)
@@ -99,10 +31,14 @@ end
 
 const _NOLOC = (Int32(0), Int32(0), Int32(0))
 
+# Per-statement debug location, captured at ingest into each `MStmt.codeloc`.
+# 1.12+: the `(line, inlined_at, ?)` triple from the `DebugInfoStream`. 1.11: the
+# single linetable index `stmts.line[pc]` stashed in slot 1 (slots 2/3 unused),
+# so `capture_debuginfo` can rebuild the SCI line map without a dense round-trip.
 @static if VERSION >= v"1.12-"
-    _codeloc(di, pc::Int) = CC.getdebugidx(di, pc)::NTuple{3, Int32}
+    _codeloc(ir::IRCode, pc::Int) = CC.getdebugidx(ir.debuginfo, pc)::NTuple{3, Int32}
 else
-    _codeloc(di, pc::Int) = _NOLOC
+    _codeloc(ir::IRCode, pc::Int) = (Int32(ir.stmts.line[pc]), Int32(0), Int32(0))
 end
 
 """
@@ -118,7 +54,6 @@ function ingest(ir::IRCode)
     blocks = [MBlock() for _ in 1:nb]
     types = Dict{Int, Any}()
     codelocs = Dict{Int, NTuple{3, Int32}}()
-    flags = Dict{Int, UInt32}()
 
     # Per block: parallel to args, the phi's (pred_bb → value) map. Transient,
     # consumed below to fill edge operands.
@@ -133,13 +68,12 @@ function ingest(ir::IRCode)
         last_loc = _NOLOC
         for si in first(bb.stmts):last(bb.stmts)
             stmt = ir.stmts.stmt[si]
-            loc = _codeloc(di, si)
+            loc = _codeloc(ir, si)
             last_loc = loc
             if stmt isa PhiNode
                 push!(mb.args, si)
                 types[si] = ir.stmts.type[si]
                 codelocs[si] = loc
-                flags[si] = ir.stmts.flag[si]
                 ev = Dict{Int, Any}()
                 for (k, edge) in enumerate(stmt.edges)
                     if isassigned(stmt.values, k)
@@ -150,14 +84,12 @@ function ingest(ir::IRCode)
             elseif stmt isa GotoNode || stmt isa GotoIfNot || stmt isa ReturnNode
                 term_stmt = stmt
                 mb.term_codeloc = loc
-                mb.term_type = ir.stmts.type[si]
             else
                 push!(mb.body, MStmt(si, stmt, ir.stmts.type[si], loc, ir.stmts.flag[si]))
             end
         end
-        if term_stmt === nothing            # fallthrough block
-            mb.term_codeloc = last_loc
-            mb.term_type = i < nb ? Any : Union{}   # goto-next, or unreachable dead-end
+        if term_stmt === nothing            # fallthrough block: goto-next, or
+            mb.term_codeloc = last_loc      # unreachable dead-end if last (MReturn)
         end
         mb.term = _ingest_term(term_stmt, i, bb, nb)
     end
@@ -168,7 +100,7 @@ function ingest(ir::IRCode)
     end
 
     valid_worlds = @static VERSION >= v"1.12-" ? ir.valid_worlds : nothing
-    return MCFG(blocks, 1, collect(1:nb), types, codelocs, flags,
+    return MCFG(blocks, 1, types, codelocs,
                 length(ir.stmts.stmt) + 1,
                 copy(ir.argtypes), copy(ir.sptypes), di, valid_worlds)
 end
@@ -213,13 +145,62 @@ function _fill_edge!(e::MEdge, src::Int, blocks, phivals, types)
 end
 
 #=============================================================================
- emit: MCFG → IRCode  (block-arg + edge-operands → phi)
+ capture_debuginfo: MCFG → (debuginfo table, line_map)
+
+ The SCI resolves a statement's source location by `line_map[ssa_idx]` (negative =
+ direct PC into the table; positive = anchor to another id to follow) + the table.
+ Build both from the `MBlock` codelocs: each statement keeps its location at its
+ own stable id, so there is no dense round-trip. The dual of `emit`'s debug-info
+ rebuild — but the lift reads `MBlock` directly, so this is all that survives.
+=============================================================================#
+
+@static if VERSION >= v"1.12-"
+    function capture_debuginfo(m::MCFG)
+        maxid = m.next_id - 1
+        line = fill(Int32(0), max(maxid, 0) * 3)
+        line_map = Dict{Int, Int}()
+        setloc!(id, loc) = (off = 3 * (id - 1);
+                            line[off + 1] = loc[1]; line[off + 2] = loc[2]; line[off + 3] = loc[3])
+        for b in m.blocks
+            for s in b.body
+                setloc!(s.id, s.codeloc); line_map[s.id] = -s.id
+            end
+            for a in b.args
+                setloc!(a, get(m.codelocs, a, _NOLOC)); line_map[a] = -a
+            end
+        end
+        di = CC.DebugInfoStream(line)
+        if m.debuginfo isa CC.DebugInfoStream
+            di.def = m.debuginfo.def
+            di.linetable = m.debuginfo.linetable
+            di.edges = copy(m.debuginfo.edges)
+        end
+        return di, line_map
+    end
+else
+    function capture_debuginfo(m::MCFG)
+        line_map = Dict{Int, Int}()
+        for b in m.blocks
+            for s in b.body
+                li = Int(s.codeloc[1]); li != 0 && (line_map[s.id] = -li)
+            end
+            for a in b.args
+                li = Int(get(m.codelocs, a, _NOLOC)[1]); li != 0 && (line_map[a] = -li)
+            end
+        end
+        debuginfo_table = m.debuginfo isa Vector ? copy(m.debuginfo) : Core.LineInfoNode[]
+        return debuginfo_table, line_map
+    end
+end
+
+#=============================================================================
+ Duplicate-edge split (run by `lift_mcfg` before the lift)
 =============================================================================#
 
 """A trampoline block `Tr: goto target(args)`. Reached only by an explicit
-`GotoNode`/`GotoIfNot`-dest edge (never fallthrough), so its placement is free."""
+`GotoNode`/`GotoIfNot`-dest edge, so it has a single predecessor."""
 _new_trampoline(target::Int, args::Vector{Any}) =
-    MBlock(Int[], MStmt[], MGoto(MEdge(target, args)), _NOLOC, Any)
+    MBlock(Int[], MStmt[], MGoto(MEdge(target, args)), _NOLOC)
 
 """Split any `GotoIfNot` whose two edges target the same block: route the false
 edge through a trampoline so the target has two distinct predecessor blocks (a
@@ -235,153 +216,6 @@ function split_duplicate_edges!(m::MCFG)
         end
     end
 end
-
-"""Build the emit order from `m.order`, preserving it exactly and inserting a
-fallthrough trampoline only where a `GotoIfNot`'s true target is not already the
-next block (Julia's `GotoIfNot` falls through to the next block on `true`). On
-un-mutated input the original order is fallthrough-correct, so this is identity;
-mutation (mux/redirect) is the only source of trampolines."""
-function layout!(m::MCFG)
-    seq = Int[]
-    base = m.order
-    for (idx, id) in enumerate(base)
-        push!(seq, id)
-        t = m.blocks[id].term
-        t isa MCondBr || continue
-        next_id = idx < length(base) ? base[idx + 1] : 0
-        if t.t.target != next_id
-            e = t.t                     # reroute true edge through a trampoline
-            tr = add_block!(m, _new_trampoline(e.target, copy(e.args)); order=false)
-            e.target = tr; empty!(e.args)
-            push!(seq, tr)
-        end
-    end
-    return seq
-end
-
-# All (predecessor id, edge operands) pairs targeting each block, in placed order.
-function _incoming_edges(m::MCFG, order::Vector{Int})
-    incoming = Dict{Int, Vector{Tuple{Int, Vector{Any}}}}()
-    for id in order
-        t = m.blocks[id].term
-        if t isa MGoto
-            push!(get!(Vector{Tuple{Int, Vector{Any}}}, incoming, t.edge.target), (id, t.edge.args))
-        elseif t isa MCondBr
-            push!(get!(Vector{Tuple{Int, Vector{Any}}}, incoming, t.t.target), (id, t.t.args))
-            push!(get!(Vector{Tuple{Int, Vector{Any}}}, incoming, t.f.target), (id, t.f.args))
-        end
-    end
-    return incoming
-end
-
-# A shallow-enough copy for emit: duplicate the mutable spine (blocks, their
-# terminators and edges, the order) so emit's trampoline insertion/redirection
-# doesn't touch the caller's MCFG. The id→type/codeloc/flag dicts are read-only
-# during emit and are shared.
-_copy_edge(e::MEdge) = MEdge(e.target, copy(e.args))
-_copy_term(t::MGoto) = MGoto(_copy_edge(t.edge))
-_copy_term(t::MCondBr) = MCondBr(t.cond, _copy_edge(t.t), _copy_edge(t.f))
-_copy_term(t::MReturn) = t
-_copy_block(b::MBlock) = MBlock(copy(b.args), copy(b.body), _copy_term(b.term),
-                                b.term_codeloc, b.term_type)
-function _copy_for_emit(m::MCFG)
-    MCFG(MBlock[_copy_block(b) for b in m.blocks], m.entry, copy(m.order),
-         m.types, m.codelocs, m.flags, m.next_id,
-         m.argtypes, m.sptypes, m.debuginfo, m.valid_worlds)
-end
-
-"""
-    emit(m::MCFG) -> IRCode
-
-Rebuild a dense `IRCode` from the mutable form. Chooses a fallthrough-preserving
-block order (inserting trampolines as needed), reconstructs phi nodes from block
-arguments + per-edge operands, remaps stable ids to dense positions, and rebuilds
-the CFG and debug info. Non-mutating: operates on a private copy of `m`.
-"""
-function emit(m_in::MCFG)
-    m = _copy_for_emit(m_in)
-    split_duplicate_edges!(m)
-    order = layout!(m)
-    incoming = _incoming_edges(m, order)
-
-    # Dense position assignment: per block, [args (phis)..., body..., terminator].
-    bb_of = Dict{Int, Int}()       # mblock id → final BB index
-    pos_of = Dict{Int, Int}()      # stable id → dense position
-    nstmts = 0
-    for (bi, id) in enumerate(order)
-        bb_of[id] = bi
-        b = m.blocks[id]
-        for a in b.args; nstmts += 1; pos_of[a] = nstmts; end
-        for s in b.body; nstmts += 1; pos_of[s.id] = nstmts; end
-        nstmts += 1                # terminator
-    end
-
-    remap_val(@nospecialize(v)) = v isa SSAValue ? SSAValue(pos_of[v.id]) : v
-    remap_stmt(@nospecialize(s)) = remap_ssa(s, remap_val)
-
-    all_stmts = Vector{Any}(undef, nstmts)
-    all_types = Vector{Any}(undef, nstmts)
-    all_flags = fill(UInt32(0), nstmts)
-    line = fill(Int32(0), nstmts * 3)
-    bb_ranges = UnitRange{Int}[]
-
-    pos = 0
-    setloc!(p, loc) = (off = 3*(p-1); line[off+1] = loc[1]; line[off+2] = loc[2]; line[off+3] = loc[3])
-    for id in order
-        b = m.blocks[id]
-        start = pos + 1
-        # Phis from block arguments. A predecessor whose operand is `Undef` is
-        # omitted (an unlisted phi edge = undef on that path), reproducing the
-        # original phi's edge set; the discriminator guarantees no live path reads
-        # an omitted slot.
-        for (j, a) in enumerate(b.args)
-            phi = PhiNode(Int32[], Any[])
-            for (src, ops) in get(incoming, id, Tuple{Int, Vector{Any}}[])
-                ops[j] isa Undef && continue
-                push!(phi.edges, Int32(bb_of[src]))
-                push!(phi.values, remap_val(ops[j]))
-            end
-            pos += 1
-            all_stmts[pos] = phi
-            all_types[pos] = get(m.types, a, Any)
-            all_flags[pos] = get(m.flags, a, UInt32(0))
-            setloc!(pos, get(m.codelocs, a, _NOLOC))
-        end
-        # Body.
-        for s in b.body
-            pos += 1
-            all_stmts[pos] = remap_stmt(s.stmt)
-            all_types[pos] = s.type
-            all_flags[pos] = s.flag
-            setloc!(pos, s.codeloc)
-        end
-        # Terminator.
-        pos += 1
-        all_stmts[pos] = _emit_term(b.term, bb_of, remap_val)
-        all_types[pos] = b.term_type
-        setloc!(pos, b.term_codeloc)
-        push!(bb_ranges, start:pos)
-    end
-
-    return _assemble(m, all_stmts, all_types, all_flags, line, bb_ranges)
-end
-
-# Reconstruct a terminator statement from the explicit-edge form. A CondBr's true
-# target is guaranteed (by layout!) to be the next block → GotoIfNot fallthrough.
-function _emit_term(t::MTerm, bb_of, remap_val)
-    if t isa MGoto
-        return GotoNode(bb_of[t.edge.target])
-    elseif t isa MCondBr
-        return GotoIfNot(remap_val(t.cond), bb_of[t.f.target])
-    else  # MReturn
-        return t.has_val ? ReturnNode(remap_val(t.val)) : ReturnNode()
-    end
-end
-
-# Build the CFG (preds/succs) and IRCode from the flat statement arrays.
-_assemble(m::MCFG, all_stmts, all_types, all_flags, line, bb_ranges) =
-    build_dense_ircode(all_stmts, all_types, all_flags, line, bb_ranges;
-                       argtypes=m.argtypes, sptypes=m.sptypes, debuginfo=m.debuginfo)
 
 #=============================================================================
  EdgeMultiplexer  (port of CFGToSCF.cpp EdgeMultiplexer::create/redirectEdge/
@@ -505,7 +339,7 @@ function create_mux!(m::MCFG, entry_list::Vector{Int}; absorb::Bool=false,
         push!(extra_ids, id)
     end
 
-    mux_id = add_block!(m, MBlock(copy(arg_ids), MStmt[], MReturn(), _NOLOC, Any))
+    mux_id = add_block!(m, MBlock(copy(arg_ids), MStmt[], MReturn(), _NOLOC))
     return EdgeMux(mux_id, entries, offset, nargs, arg_ids, disc_id, extra_ids, absorb)
 end
 
@@ -562,7 +396,7 @@ function dispatch!(m::MCFG, mux::EdgeMux; excluded::Set{Int}=Set{Int}(),
                     Bool, _NOLOC, UInt32(0)))
         t_edge = MEdge(e, slice_vals(mux, e, live))
         if i < length(targets) - 1
-            nxt = add_block!(m, MBlock(Int[], MStmt[], MReturn(), _NOLOC, Any))
+            nxt = add_block!(m, MBlock(Int[], MStmt[], MReturn(), _NOLOC))
             m.blocks[cur].term = MCondBr(SSAValue(cmp), t_edge, MEdge(nxt, Any[]))
             cur = nxt
         else
@@ -741,7 +575,7 @@ function single_exiting_latch!(m::MCFG, header::Int,
     push!(m.blocks[latch].body,
           MStmt(cmp, Expr(:call, Core.:(===), SSAValue(sr_id), 1), Bool, _NOLOC, UInt32(0)))
     header_edge = MEdge(header, slice_vals(mux, header, live))
-    exitblk = add_block!(m, MBlock(Int[], MStmt[], MReturn(), _NOLOC, Any))
+    exitblk = add_block!(m, MBlock(Int[], MStmt[], MReturn(), _NOLOC))
     m.blocks[latch].term = MCondBr(SSAValue(cmp), header_edge, MEdge(exitblk, Any[]))
 
     if isempty(exit_targets)
@@ -879,41 +713,6 @@ function normalize_one_loop_latch!(m::MCFG)
     return false
 end
 
-"""Mutate `m` until no multi-entry situation remains. Each mux strictly reduces
-the count (the mux block is single-entry by construction), so this terminates."""
-function normalize_cf!(m::MCFG)
-    changed = false
-    guard = 0
-    limit = length(m.blocks) + 16
-    # Each step collapses one multi-entry header (irreducible) or one multi-exit
-    # loop (the single-exiting latch + reduce form) — both strictly reduce the
-    # remaining count, so this terminates.
-    while normalize_one_irreducible!(m) || normalize_one_loop_latch!(m)
-        changed = true
-        guard += 1
-        guard > 4 * limit && error("normalize_cf! failed to converge (likely a mux bug)")
-    end
-    return changed
-end
-
-"""
-    normalize_cf(ir::IRCode) -> IRCode
-
-Collapse every multi-entry CFG situation (irreducible loop headers; later,
-multi-predecessor continuations) to single-entry via edge multiplexers, so the
-lift only structurizes single-entry regions. Returns `ir` unchanged when it is
-already reducible/single-entry everywhere (the common case) — no perturbation.
-"""
-function normalize_cf(ir::IRCode)
-    # Phase 1: irreducible (multi-entry) loop headers — MBlock-native mutation.
-    m = ingest(ir)
-    normalize_cf!(m) && (ir = emit(m))
-    # Phase 2: multi-predecessor branch continuations (short-circuits, nested
-    # gated bodies) — reuses the lift's branch_continuation on the (now reducible)
-    # IRCode.
-    return normalize_continuations(ir)
-end
-
 #=============================================================================
  Continuation multiplexer.
 
@@ -921,26 +720,16 @@ end
  shape `if a||b { body }`: `body` is reached from both arms, and so is the merge)
  has a multi-entry continuation. Route every edge into that continuation through
  one mux so the continuation becomes single-entry; the lift then structurizes it
- with the ordinary IfOp path (no shape-matching). This reuses the lift's own
- `branch_continuation` exclusion analysis (loop-aware), run on the current IRCode.
+ with the ordinary IfOp path (no shape-matching). Reuses the lift's own
+ `branch_continuation` exclusion analysis (loop-aware) directly on the MBlock CFG.
 =============================================================================#
-
-# The two successors of a conditional block: false = GotoIfNot.dest, true = the
-# other CFG successor (mirrors emit_branch!).
-function _condbr_dests(ir::IRCode, E::Int)
-    g = find_terminator(ir, E)::GotoIfNot
-    false_dest = g.dest
-    succs = ir.cfg.blocks[E].succs
-    true_dest = length(succs) == 1 ? only(succs) : first(s for s in succs if s != false_dest)
-    return true_dest, false_dest
-end
 
 # Minimal LoopCtx for the innermost loop enclosing `E` — `branch_continuation`
 # uses only `header`/`loop_blocks` (to skip the loop's back edge and exit edges,
 # which are not part of a branch's forward continuation).
-function _enclosing_loop_ctx(ctx::StructurizeCtx, E::Int)
+function enclosing_loop_ctx(loops::Dict{Int, Set{Int}}, E::Int)
     best_h = 0; best_body = nothing; best_size = typemax(Int)
-    for (h, body) in ctx.loop_map
+    for (h, body) in loops
         if E in body && length(body) < best_size
             best_h = h; best_body = body; best_size = length(body)
         end
@@ -949,56 +738,108 @@ function _enclosing_loop_ctx(ctx::StructurizeCtx, E::Int)
     return LoopCtx(best_h, best_body, IRValue[], IRValue[])
 end
 
-# Find one conditional with a multi-entry continuation; return (E, entries) or
-# nothing. `entries` are the distinct continuation blocks (>1).
-function _find_multientry_continuation(ctx::StructurizeCtx)
-    ir = ctx.ir
-    all_blocks = Set(1:length(ir.cfg.blocks))
-    for E in 1:length(ir.cfg.blocks)
-        find_terminator(ir, E) isa GotoIfNot || continue
-        lctx = _enclosing_loop_ctx(ctx, E)
-        true_dest, false_dest = _condbr_dests(ir, E)
+"""Find one conditional with a multi-entry continuation and route every edge into
+that continuation through one mux (MLIR `createSingleEntryBlock` for the
+continuation), making it single-entry. Returns `true` if it muxed one. After this
+the lift's ordinary IfOp path handles short-circuits, N-way merges, and nested
+gated bodies uniformly — `find_branch_regions` always finds a singleton merge."""
+function normalize_one_continuation!(m::MCFG)
+    cfg = build_cfg(m)
+    domtree = construct_domtree(cfg)
+    loops = natural_loops_m(m)
+    all_blocks = Set(1:length(m.blocks))
+    for E in 1:length(m.blocks)
+        t = m.blocks[E].term
+        t isa MCondBr || continue
+        true_dest, false_dest = t.t.target, t.f.target
+        lctx = enclosing_loop_ctx(loops, E)
         then_blocks, else_blocks, _ =
-            find_branch_regions(ctx, E, true_dest, false_dest, all_blocks, lctx)
-        entries, notcont = branch_continuation(ctx, E, true_dest, false_dest,
+            find_branch_regions(cfg, domtree, E, true_dest, false_dest, all_blocks, lctx)
+        entries, notcont = branch_continuation(cfg, domtree, E, true_dest, false_dest,
                                                then_blocks, else_blocks, all_blocks, lctx)
-        length(entries) > 1 && return (E, entries, notcont)
-    end
-    return nothing
-end
-
-"""
-    normalize_continuations(ir::IRCode) -> IRCode
-
-Collapse every multi-predecessor branch continuation to single-entry with an edge
-multiplexer (MLIR `createSingleEntryBlock` for the continuation), to a fixpoint.
-Returns `ir` unchanged when no conditional has a multi-entry continuation. After
-this, `find_branch_regions` always finds a singleton merge, so the lift's ordinary
-IfOp path handles short-circuits, N-way merges, and nested gated bodies uniformly.
-"""
-function normalize_continuations(ir::IRCode)
-    guard = 0
-    while true
-        ctx = StructurizeCtx(ir)
-        found = _find_multientry_continuation(ctx)
-        found === nothing && return ir
-        E, entries, notcont = found
+        length(entries) > 1 || continue
 
         # The continuation edges: every edge from a branch-region block (notcont)
         # into a continuation entry. Routing them through one mux makes the
-        # continuation single-entry. Entries keep their phis (a merge may also be
+        # continuation single-entry. Entries keep their args (a merge may also be
         # reached from inside the continuation), so absorb=false.
         entryset = Set(entries)
         refs = EdgeRef[]
-        m = ingest(ir)
-        for b in notcont, succ in ir.cfg.blocks[b].succs
+        for b in sort!(collect(notcont)), succ in cfg.blocks[b].succs
             succ in entryset && append!(refs, edge_refs(m, b, succ))
         end
         single_entry_mux!(m, refs)
-        ir = emit(m)
-
-        guard += 1
-        guard > length(ir.cfg.blocks) + 64 &&
-            error("normalize_continuations failed to converge (likely a mux bug)")
+        return true
     end
+    return false
+end
+
+"""Mutate `m` until no multi-entry situation remains. Each step collapses one
+multi-entry header (irreducible), one multi-exit loop (the single-exiting latch +
+reduce form), or one multi-predecessor branch continuation — all strictly reduce
+the remaining count (the mux block is single-entry by construction), so this
+terminates. The lift then only ever structurizes single-entry regions."""
+function normalize_cf!(m::MCFG)
+    changed = false
+    guard = 0
+    limit = length(m.blocks) + 16
+    while normalize_one_irreducible!(m) || normalize_one_loop_latch!(m) ||
+          normalize_one_continuation!(m)
+        changed = true
+        guard += 1
+        guard > 8 * limit && error("normalize_cf! failed to converge (likely a mux bug)")
+    end
+    return changed
+end
+
+"""
+    normalize_cf(ir::IRCode) -> MCFG
+
+Collapse every multi-entry CFG situation (irreducible loop headers, multi-exit
+loops, multi-predecessor continuations) to single-entry via edge multiplexers, so
+the lift only structurizes single-entry regions. One `ingest`, one mutate fixpoint
+over the `MCFG`, no dense round-trip — the lift (`lift_mcfg`) reads the returned
+`MCFG` directly.
+"""
+function normalize_cf(ir::IRCode)
+    m = ingest(ir)
+    normalize_cf!(m)
+    return m
+end
+
+"""
+    lift_mcfg(m::MCFG; validate=true, promote=true) -> StructuredIRCode
+
+Lift a normalized `MCFG` to a `StructuredIRCode`. `split_duplicate_edges!` first
+routes any `GotoIfNot` whose two edges target the same block through a trampoline,
+so every predecessor reaches a block by at most one edge (the lift reads "what
+predecessor P contributes" as a single edge operand; a `cond ? a : b` shape needs
+the two predecessors distinct). Debug info comes from the `MBlock` codelocs.
+"""
+function lift_mcfg(m::MCFG; validate::Bool=true, promote::Bool=true)
+    split_duplicate_edges!(m)
+    debuginfo_table, line_map = capture_debuginfo(m)
+    valid_worlds = m.valid_worlds isa WorldRange ? m.valid_worlds :
+                   WorldRange(typemin(UInt), typemax(UInt))
+    sci = StructuredIRCode(copy(m.argtypes), copy(m.sptypes), Block(), 0, 0,
+                           debuginfo_table, line_map, valid_worlds)
+    entry, max_ssa, max_arg, updated_line_map = structurize(m, line_map; promote)
+    sci.entry = entry
+    sci.max_ssa_idx = max_ssa
+    sci.max_arg_idx = max_arg
+    merge!(sci.line_map, updated_line_map)
+
+    # Parent chain (entry → SCI, sub-blocks → containing block) after structurize +
+    # promote, since promote_loops! replaces block.body without going through push!.
+    sci.entry.parent = sci
+    fix_parents!(sci.entry)
+
+    if validate
+        validate_scf(sci.entry)
+        validate_no_phis(sci.entry)
+        validate_terminators(sci)
+        validate_ssa_defs(sci)
+        validate_ssa_uniqueness(sci)
+    end
+    return sci
 end

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -7,17 +7,25 @@
 =============================================================================#
 
 """
-    MergePhiInfo
+    MergeInfo
 
-Info about one block argument at a merge/exit block. `ssa_idx` is the argument's
-stable id; `edge_values` maps predecessor block index → the operand that edge
-contributes to this argument. Built from the `MBlock` args + per-edge operands by
-[`extract_merge_phis`](@ref) — the lift then reasons in the same predecessor-keyed
-terms whether the value came from a Julia phi or an MLIR-style block argument.
+The merge/continuation block of an `IfOp`, in native block-argument form. `merge`
+is the block id; `positions` are the indices of its block args that are *live*
+(some predecessor edge carries a real, non-`Undef` operand) and so become `IfOp`
+results; `ids`/`types` are those args' stable ids and (widened) types. Built once
+by [`merge_info`](@ref).
+
+Each arm's `YieldOp` is then just the operands *its own* exit edge carries to
+`merge` — `edge_operands(m, arm_exit, merge)` read position by position — instead
+of a predecessor-keyed phi reconstruction with a reverse edge lookup. "What value
+does this arm contribute to the merge's k-th arg" *is* the k-th operand on the
+arm's edge (the MLIR model).
 """
-struct MergePhiInfo
-    ssa_idx::Int
-    edge_values::Dict{Int, Any}
+struct MergeInfo
+    merge::Int
+    positions::Vector{Int}
+    ids::Vector{Int}
+    types::Vector{Any}
 end
 
 """
@@ -65,7 +73,7 @@ Recursively structurize a set of blocks into a single Block.
 - `loop_ctx`: if provided, back-edges/exits become ContinueOp/BreakOp.
 """
 function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set{Int};
-                              merge_phis::Union{Nothing, Vector{MergePhiInfo}}=nothing,
+                              merge_phis::Union{Nothing, MergeInfo}=nothing,
                               loop_ctx::Union{Nothing, LoopCtx}=nothing)
     block = Block()
     m = ctx.m::MCFG
@@ -120,9 +128,11 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
         end
     end
 
-    # Region ended — set terminator if not already set
+    # Region ended — yield to the merge if not already terminated. The arm's exit
+    # block is the walk's tracked `last_block`; its edge to the merge carries the
+    # yield operands directly.
     if block.terminator === nothing && merge_phis !== nothing
-        set_exit_yield!(block, ctx, merge_phis, last_block)
+        yield_to_merge!(block, ctx, last_block, merge_phis)
     end
 
     return block
@@ -217,18 +227,6 @@ end
  Branch Lifting (IfOp)
 =============================================================================#
 
-"""True iff the branch at `current` has no continuation edges — both arms
-diverge (return/throw/break/continue). The only legitimate reason
-`find_branch_regions` returns `merge === nothing` once continuations are
-single-entry (post `normalize_cf`)."""
-function _both_arms_diverge(ctx::StructurizeCtx, current::Int, true_dest::Int,
-                            false_dest::Int, then_blocks::Set{Int}, else_blocks::Set{Int},
-                            region_blocks::Set{Int}, loop_ctx::Union{Nothing, LoopCtx})
-    entries, _ = branch_continuation(ctx.cfg, ctx.domtree, current, true_dest, false_dest,
-                                     then_blocks, else_blocks, region_blocks, loop_ctx)
-    return isempty(entries)
-end
-
 """
     emit_branch!(block, ctx, current, condbr, region_blocks, outer_merge_phis) -> next
 
@@ -237,7 +235,7 @@ continue with, or nothing if both branches exit/diverge.
 """
 function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
                       condbr::MCondBr, region_blocks::Set{Int},
-                      outer_merge_phis::Union{Nothing, Vector{MergePhiInfo}},
+                      outer_merge_phis::Union{Nothing, MergeInfo},
                       loop_ctx::Union{Nothing, LoopCtx}=nothing)
     # MCondBr carries explicit true/false edges (no fallthrough/succ derivation).
     true_dest = condbr.t.target
@@ -253,14 +251,10 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
     # no shape-matching (`find_gated_body` is gone; invariant I4).
     then_blocks, else_blocks, merge = find_branch_regions(
         ctx.cfg, ctx.domtree, current, true_dest, false_dest, region_blocks, loop_ctx)
-    @assert merge !== nothing || _both_arms_diverge(ctx, current, true_dest, false_dest,
-                                                    then_blocks, else_blocks, region_blocks, loop_ctx) """
-        multi-entry continuation reached the lift at BB$current — normalize_cf's \
-        continuation multiplexer should have collapsed it (internal error)"""
 
-    # If merge exists and is in region, extract its block args (the "phis").
-    # Skip args at loop headers: a header is never a branch merge now — the
-    # pre-header (`normalize_one_preheader!`) routes every multi-entry header's
+    # If merge exists and is in region, read its block args (the "phis") as a
+    # MergeInfo. Skip args at loop headers: a header is never a branch merge now —
+    # the pre-header (`normalize_one_preheader!`) routes every multi-entry header's
     # entry edges through a pre-header, so the branch's continuation is that
     # pre-header, not the header itself.
     #
@@ -268,8 +262,7 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
     # is genuinely arg-free: the walk continues through it without a separate
     # pass-through step. A no-arg merge yields `nothing` here.
     merge_phis = if merge !== nothing && merge ∈ region_blocks && !haskey(ctx.loop_map, merge)
-        phis = extract_merge_phis(ctx, merge, region_blocks)
-        isempty(phis) ? nothing : phis
+        merge_info(ctx, merge)
     else
         nothing
     end
@@ -302,13 +295,11 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
 
     if merge !== nothing && merge ∈ region_blocks && merge_phis !== nothing
         # --- Inner merge exists: standard IfOp ---
-        set_branch_yields!(then_blk, merge_phis, then_blocks, current, ctx)
-        set_branch_yields!(else_blk, merge_phis, else_blocks, current, ctx)
+        set_branch_yields!(then_blk, ctx, merge_phis, then_blocks, current)
+        set_branch_yields!(else_blk, ctx, merge_phis, else_blocks, current)
 
         if_op = IfOp(cond, then_blk, else_blk)
-        phi_indices = [p.ssa_idx for p in merge_phis]
-        phi_types = [ctx.types[p.ssa_idx] for p in merge_phis]
-        emit_ifop_result!(block, if_op, phi_indices, phi_types, ctx, branch_anchor)
+        emit_ifop_result!(block, if_op, merge_phis.ids, merge_phis.types, ctx, branch_anchor)
         return merge
     elseif merge !== nothing && merge ∈ region_blocks
         # Merge exists but no args
@@ -332,8 +323,8 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
 
         if_op = IfOp(cond, then_blk, else_blk)
 
-        if outer_merge_phis !== nothing && !isempty(outer_merge_phis)
-            phi_types = [ctx.types[p.ssa_idx] for p in outer_merge_phis]
+        if outer_merge_phis !== nothing
+            phi_types = outer_merge_phis.types
             # The IfOp yields the outer-merge values only if at least one arm
             # actually yields (reaches the outer continuation). If BOTH arms
             # diverge (return/break/continue), the IfOp has no results — and this
@@ -366,95 +357,68 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
     end
 end
 
-"""Set yield terminator on a branch block for merge phis, if not already set."""
-function set_branch_yields!(blk::Block, merge_phis::Vector{MergePhiInfo},
-                            branch_blocks::Set{Int}, branch_entry::Int,
-                            ctx::StructurizeCtx)
-    blk.terminator !== nothing && return  # already set (e.g., ReturnNode, inner yield)
+"""Set `blk`'s terminator to the `YieldOp` carrying what `exit_block` contributes
+to `minfo.merge`: for each live merge-arg position, the operand on edge `exit_block
+→ merge` (`edge_operands`), remapped through `ssa_remap`. The arm yields *its own*
+edge — no predecessor-keyed reconstruction.
 
-    # Find the exit block: the block in branch_blocks (or branch_entry if empty)
-    # whose edge feeds the merge phis.
-    exit_block = find_exit_predecessor(merge_phis, branch_blocks, branch_entry)
-    blk.terminator = make_yield_for_edge(merge_phis, exit_block, blk, ctx)
+`Undef` (an unassigned phi slot) or a missing edge (`exit_block` does not reach the
+merge — an arm that diverged, whose yield is then dead) becomes a typed `Undef`. If
+the arm already redefines a merge arg at its (remapped) id — e.g. a nested IfOp on
+the same merge emitted the `getfield` there — that in-block definition is preferred
+over the raw edge operand."""
+function yield_to_merge!(blk::Block, ctx::StructurizeCtx, exit_block::Int, minfo::MergeInfo)
+    ops = edge_operands(ctx.m::MCFG, exit_block, minfo.merge)
+    vals = IRValue[]
+    for (j, k) in enumerate(minfo.positions)
+        v = ops === nothing ? Undef(minfo.types[j]) : ops[k]
+        if v isa Undef
+            push!(vals, Undef(minfo.types[j]))
+        else
+            v = remap_ssa_ref(v, ctx.ssa_remap)
+            idx = get(ctx.ssa_remap, minfo.ids[j], minfo.ids[j])
+            push!(vals, haskey(blk.body, idx) ? SSAValue(idx) : v)
+        end
+    end
+    blk.terminator = YieldOp(vals)
+end
+
+"""The arm's exit block: the seed (in `blocks`, else the branch source `fallback`)
+whose edge targets `merge`. Single-entry continuations (post `normalize_cf`)
+guarantee the arm's exit is a *direct* merge predecessor, so a seed lookup
+suffices — no reachability search. `fallback` is returned when no seed reaches the
+merge (an arm that diverged); `yield_to_merge!` then yields dead `Undef`s."""
+function branch_exit_block(ctx::StructurizeCtx, merge::Int, blocks::Set{Int}, fallback::Int)
+    m = ctx.m::MCFG
+    for b in (isempty(blocks) ? (fallback,) : blocks)
+        edge_operands(m, b, merge) !== nothing && return b
+    end
+    return fallback
+end
+
+"""Set the yield terminator on an arm block, if not already set (a `ReturnNode` /
+inner yield takes precedence). The exit block is the arm block that reaches the
+merge directly."""
+function set_branch_yields!(blk::Block, ctx::StructurizeCtx, minfo::MergeInfo,
+                            branch_blocks::Set{Int}, branch_entry::Int)
+    blk.terminator !== nothing && return
+    yield_to_merge!(blk, ctx, branch_exit_block(ctx, minfo.merge, branch_blocks, branch_entry), minfo)
 end
 
 function set_yield_if_needed!(blk::Block)
     blk.terminator === nothing && (blk.terminator = YieldOp())
 end
 
-"""Create an empty branch block with appropriate terminator for its destination."""
+"""Create an empty branch arm's block. The arm is just the edge `from → dest`, so
+when `dest` is the merge the block yields the operands that edge carries
+(`from`'s edge to the merge); a loop boundary becomes a break/continue instead."""
 function make_empty_branch_block(ctx::StructurizeCtx, dest::Int, from::Int,
-                                  merge_phis::Union{Nothing, Vector{MergePhiInfo}},
+                                  minfo::Union{Nothing, MergeInfo},
                                   loop_ctx::Union{Nothing, LoopCtx})
     b = Block()
-    # Loop boundary (continue / break)?
     if loop_ctx !== nothing && resolve_loop_exit!(b, ctx, dest, loop_ctx)
         return b
     end
-    # Merge phis? Find the phi-edge value this empty arm contributes and yield it.
-    if merge_phis !== nothing && !isempty(merge_phis)
-        pred = find_exit_predecessor(merge_phis, Set{Int}([dest]), from)
-        b.terminator = make_yield_for_edge(merge_phis, pred, b, ctx)
-    end
+    minfo !== nothing && yield_to_merge!(b, ctx, from, minfo)
     return b
-end
-
-"""
-    find_exit_predecessor(merge_phis, blocks, fallback)
-
-The predecessor of the merge whose edge carries this branch's values: the arm
-block (in `blocks`) that directly feeds the merge, else the branch source
-`fallback`. Single-entry continuations (post `normalize_cf`) guarantee the arm's
-exit block is a *direct* merge predecessor — its terminator edge targets the merge
-— so a seed/fallback lookup suffices; no reachability search (the old pass-through
-BFS dissolved on the block-arg / edge-operand form).
-"""
-function find_exit_predecessor(merge_phis::Vector{MergePhiInfo}, blocks::Set{Int},
-                                fallback::Int)
-    seeds = isempty(blocks) ? Set{Int}([fallback]) : blocks
-    for b in seeds, phi in merge_phis
-        haskey(phi.edge_values, b) && return b
-    end
-    return fallback
-end
-
-"""Create a YieldOp with values from merge phis for a given predecessor edge."""
-function make_yield_for_edge(merge_phis::Vector{MergePhiInfo},
-                              pred::Int, blk::Block, ctx::StructurizeCtx)
-    yield_values = IRValue[]
-    remap = ctx.ssa_remap
-    for phi in merge_phis
-        val = get(phi.edge_values, pred, nothing)
-        if val !== nothing
-            val = remap_ssa_ref(val, remap)
-            resolved = resolve_yield_value(blk, phi.ssa_idx, val, remap)
-            push!(yield_values, resolved)
-        else
-            push!(yield_values, Undef(ctx.types[phi.ssa_idx]))
-        end
-    end
-    return YieldOp(yield_values)
-end
-
-"""
-Set a region's exit terminator on `blk`: resolve which phi-edge predecessor this
-region reaches and yield that value. Multi-entry continuations (short-circuit
-`&&`/`||`) were collapsed to single-entry upstream by `normalize_cf`, so the
-yield value is always visible — no tail duplication.
-"""
-function set_exit_yield!(blk::Block, ctx::StructurizeCtx,
-                          merge_phis::Vector{MergePhiInfo}, last_block::Int)
-    pred = find_exit_predecessor(merge_phis, Set{Int}([last_block]), last_block)
-    blk.terminator = make_yield_for_edge(merge_phis, pred, blk, ctx)
-    return blk.terminator
-end
-
-"""
-If the block already defines `phi_ssa_idx` (or its remapped index), yield that SSAValue.
-Otherwise yield `default_val`.
-"""
-function resolve_yield_value(blk::Block, phi_ssa_idx::Int, default_val,
-                              remap::Dict{Int, Int}=Dict{Int,Int}())
-    idx = get(remap, phi_ssa_idx, phi_ssa_idx)
-    haskey(blk.body, idx) ? SSAValue(idx) : default_val
 end

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -259,20 +259,15 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
         continuation multiplexer should have collapsed it (internal error)"""
 
     # If merge exists and is in region, extract its block args (the "phis").
-    # Skip args at loop headers — UNLESS the header has multiple non-loop predecessors
-    # (entry multiplexer case: the branch must yield the correct entry values).
-    is_multi_entry_header = if merge !== nothing && haskey(ctx.loop_map, merge) &&
-                               loop_ctx === nothing  # not inside a loop
-        loop_body = ctx.loop_map[merge]
-        count(p -> p ∉ loop_body, ctx.cfg.blocks[merge].preds) > 1
-    else
-        false
-    end
+    # Skip args at loop headers: a header is never a branch merge now — the
+    # pre-header (`normalize_one_preheader!`) routes every multi-entry header's
+    # entry edges through a pre-header, so the branch's continuation is that
+    # pre-header, not the header itself.
+    #
     # Continuation-by-exclusion finds the *real* merge directly, so a no-arg merge
     # is genuinely arg-free: the walk continues through it without a separate
     # pass-through step. A no-arg merge yields `nothing` here.
-    merge_phis = if merge !== nothing && merge ∈ region_blocks &&
-                   (!haskey(ctx.loop_map, merge) || is_multi_entry_header)
+    merge_phis = if merge !== nothing && merge ∈ region_blocks && !haskey(ctx.loop_map, merge)
         phis = extract_merge_phis(ctx, merge, region_blocks)
         isempty(phis) ? nothing : phis
     else

--- a/src/structurize/walk.jl
+++ b/src/structurize/walk.jl
@@ -1,12 +1,19 @@
 #=============================================================================
- Core Algorithm
+ Core Algorithm — the lift, reading the explicit-edge `MBlock` form directly.
+
+ Block arguments + per-edge operands replace Julia phi nodes (the MLIR model), so
+ "what value does predecessor P contribute to block B's k-th argument" is just the
+ operand on edge P→B (`edge_operands`) — no phi-node scanning, no dense round-trip.
 =============================================================================#
 
 """
     MergePhiInfo
 
-Info about a phi node at a merge/exit block. `edge_values` maps predecessor
-block index → value on that edge.
+Info about one block argument at a merge/exit block. `ssa_idx` is the argument's
+stable id; `edge_values` maps predecessor block index → the operand that edge
+contributes to this argument. Built from the `MBlock` args + per-edge operands by
+[`extract_merge_phis`](@ref) — the lift then reasons in the same predecessor-keyed
+terms whether the value came from a Julia phi or an MLIR-style block argument.
 """
 struct MergePhiInfo
     ssa_idx::Int
@@ -26,10 +33,33 @@ struct LoopCtx
     break_values::Vector{IRValue}
 end
 
+"""The operands edge `src`→`dst` carries (parallel to `dst`'s block arguments), or
+`nothing` if `src` has no edge to `dst`. A degenerate `GotoIfNot` whose two edges
+target the same block is split away by [`split_duplicate_edges!`](@ref) before the
+lift, so each predecessor reaches a block by at most one edge here."""
+function edge_operands(m, src::Int, dst::Int)
+    t = m.blocks[src].term
+    if t isa MGoto
+        t.edge.target == dst && return t.edge.args
+    elseif t isa MCondBr
+        t.t.target == dst && return t.t.args
+        t.f.target == dst && return t.f.args
+    end
+    return nothing
+end
+
+"""The stable id of a block's last / first body statement (0 if the body is
+empty), used as a debug-info anchor for synthesized ops — the branch condition
+(last body stmt) for an IfOp, the header's first stmt for a loop."""
+last_body_id(ctx::StructurizeCtx, b::Int) =
+    (body = (ctx.m::MCFG).blocks[b].body; isempty(body) ? 0 : last(body).id)
+first_body_id(ctx::StructurizeCtx, b::Int) =
+    (body = (ctx.m::MCFG).blocks[b].body; isempty(body) ? 0 : first(body).id)
+
 """
     structurize_region!(ctx, entry, region_blocks; merge_phis, loop_ctx) -> Block
 
-Recursively structurize a set of basic blocks into a single Block.
+Recursively structurize a set of blocks into a single Block.
 
 - `merge_phis`: if provided, the block's terminator will be YieldOp with merge values.
 - `loop_ctx`: if provided, back-edges/exits become ContinueOp/BreakOp.
@@ -38,8 +68,7 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
                               merge_phis::Union{Nothing, Vector{MergePhiInfo}}=nothing,
                               loop_ctx::Union{Nothing, LoopCtx}=nothing)
     block = Block()
-    ir = ctx.ir
-    nblocks = length(ir.cfg.blocks)
+    m = ctx.m::MCFG
     current = entry
     last_block = entry
 
@@ -51,6 +80,13 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
     while current !== nothing && current ∈ region_blocks
         last_block = current
 
+        # A block argument with a single predecessor is a "phi with one edge" — a
+        # pure copy left by an edge multiplexer's dispatch. Rename it to that
+        # edge's operand (the MBlock equivalent of materialize_single_edge_phi!);
+        # header / merge args (≥2 preds) are owned by the loop / branch machinery
+        # and left untouched here.
+        bind_single_pred_args!(block, ctx, current)
+
         # --- Loop header? (only if not already inside this loop) ---
         if loop_ctx === nothing || current != loop_ctx.header
             loop_body = get_loop_at(ctx, current, region_blocks)
@@ -59,7 +95,7 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
                 # Update last_block to the loop's exit predecessor (for merge phi lookup)
                 if loop_exit !== nothing
                     for b in loop_body
-                        loop_exit ∈ ir.cfg.blocks[b].succs && (last_block = b)
+                        loop_exit ∈ ctx.cfg.blocks[b].succs && (last_block = b)
                     end
                 end
                 current = advance(loop_exit)
@@ -67,40 +103,35 @@ function structurize_region!(ctx::StructurizeCtx, entry::Int, region_blocks::Set
             end
         end
 
-        # --- Emit non-phi/non-terminator statements ---
+        # --- Emit body statements (block args are not statements) ---
         emit_block_stmts!(block, ctx, current)
 
         # --- Handle terminator ---
-        term = find_terminator(ir, current)
-
-        if term isa ReturnNode
-            if !isempty(ctx.ssa_remap) && isdefined(term, :val)
-                val = remap_ssa_ref(term.val, ctx.ssa_remap)
-                block.terminator = val === term.val ? term : ReturnNode(val)
-            else
-                block.terminator = term
-            end
+        term = m.blocks[current].term
+        if term isa MReturn
+            block.terminator = make_return(ctx, term)
             return block
-        elseif term isa GotoNode
-            current = advance(term.label)
-        elseif term isa GotoIfNot
-            next = emit_branch!(block, ctx, current, term, region_blocks, merge_phis, loop_ctx)
+        elseif term isa MGoto
+            current = advance(term.edge.target)
+        else  # MCondBr
+            next = emit_branch!(block, ctx, current, term::MCondBr, region_blocks, merge_phis, loop_ctx)
             next === nothing && return block
             current = advance(next)
-        else
-            # Fallthrough
-            next = current + 1
-            current = advance(next <= nblocks ? next : nothing)
         end
     end
 
     # Region ended — set terminator if not already set
     if block.terminator === nothing && merge_phis !== nothing
-        set_exit_yield!(block, ir, ctx, merge_phis, last_block)
+        set_exit_yield!(block, ctx, merge_phis, last_block)
     end
 
     return block
 end
+
+"""Reconstruct the SCI return terminator from an `MReturn` (a value return, a bare
+`return`, or an unreachable dead-end)."""
+make_return(ctx::StructurizeCtx, t::MReturn) =
+    t.has_val ? ReturnNode(remap_ssa_ref(t.val, ctx.ssa_remap)) : ReturnNode()
 
 """
 Resolve a destination block, checking loop boundaries.
@@ -143,55 +174,43 @@ end
  Statement Emission
 =============================================================================#
 
-function emit_block_stmts!(block::Block, ctx::StructurizeCtx, bb_idx::Int)
-    ir = ctx.ir
+function emit_block_stmts!(block::Block, ctx::StructurizeCtx, b::Int)
+    m = ctx.m::MCFG
     remap = ctx.ssa_remap
-    bb = ir.cfg.blocks[bb_idx]
-    for si in first(bb.stmts):last(bb.stmts)
-        stmt = ir.stmts.stmt[si]
-        if stmt isa PhiNode
-            materialize_single_edge_phi!(block, ctx, si, stmt)
-            continue
+    for s in m.blocks[b].body
+        idx = get(remap, s.id, s.id)
+        stmt = remap_stmt(s.stmt, remap)
+        push!(block, idx, stmt, s.type, s.flag)
+        idx != s.id && anchor_line!(ctx, idx, s.id)
+    end
+end
+
+"""Bind the single-predecessor block arguments of `b`. A block argument fed by
+exactly one predecessor edge is a pure copy (`arg := that edge's operand`) — left
+by an edge multiplexer's dispatch (an entry reached from one dispatch arm). An
+SSA-valued operand becomes a rename (`ssa_remap`); a constant/argument/undef
+operand is materialized as a copy at the arg's id. Multi-predecessor args (loop
+headers, branch merges) carry ≥2 distinct edge operands and are resolved by the
+loop / branch machinery instead, so they are skipped here."""
+function bind_single_pred_args!(block::Block, ctx::StructurizeCtx, b::Int)
+    m = ctx.m::MCFG
+    args = m.blocks[b].args
+    isempty(args) && return
+    preds = ctx.cfg.blocks[b].preds
+    length(preds) == 1 || return
+    ops = edge_operands(m, only(preds), b)
+    ops === nothing && return
+    for (k, arg) in enumerate(args)
+        haskey(ctx.ssa_remap, arg) && continue   # already renamed by an enclosing pass
+        haskey(block.body, arg) && continue       # already a definition at this id
+        v = ops[k]
+        if v isa SSAValue
+            ctx.ssa_remap[arg] = get(ctx.ssa_remap, v.id, v.id)
+        else
+            push!(block, arg, v, get(ctx.types, arg, Any))   # constant / argument / undef copy
+            anchor_line!(ctx, arg, arg)
         end
-        (stmt isa GotoNode || stmt isa GotoIfNot || stmt isa ReturnNode) && continue
-        idx = get(remap, si, si)
-        stmt = remap_stmt(stmt, remap)
-        push!(block, idx, stmt, ir.stmts.type[si], ir.stmts.flag[si])
-        idx != si && anchor_line!(ctx, idx, si)
     end
-end
-
-"""A phi reached on a single live edge `φ(#p => v)` is a pure copy `phi := v` —
-left by the edge multiplexer's dispatch (an entry reached from exactly one
-trampoline). The walk skips multi-edge phis (the loop-header and branch-merge
-machinery owns those, both ≥2 edges); a single-edge phi is otherwise dropped, so
-its downstream uses become "SSA used but not defined". Materialize it as a rename
-(`ssa_remap`): every reader resolving SSAs through `ssa_remap` then sees the
-source value, with no extra statement to misplace across a loop boundary (a copy
-statement snapshotting a loop-carried value miscompiled empty loops to infinite).
-Readers that consult the *raw* phi index — `emit_loop!`'s loop-carried init/carry
-values — apply `ssa_remap` explicitly."""
-function materialize_single_edge_phi!(block::Block, ctx::StructurizeCtx, si::Int, phi::PhiNode)
-    count(k -> isassigned(phi.values, k), eachindex(phi.values)) == 1 || return
-    haskey(ctx.ssa_remap, si) && return            # already renamed by an enclosing pass
-    haskey(block.body, si) && return               # already a definition at this index
-    k = findfirst(k -> isassigned(phi.values, k), eachindex(phi.values))
-    v = phi.values[k]
-    if v isa SSAValue
-        ctx.ssa_remap[si] = get(ctx.ssa_remap, v.id, v.id)
-    else
-        push!(block, si, v, ctx.types[si])         # constant copy (no SSA to track)
-        anchor_line!(ctx, si, si)
-    end
-end
-
-function find_terminator(ir::IRCode, bb_idx::Int)
-    bb = ir.cfg.blocks[bb_idx]
-    for si in first(bb.stmts):last(bb.stmts)
-        s = ir.stmts.stmt[si]
-        (s isa GotoIfNot || s isa GotoNode || s isa ReturnNode) && return s
-    end
-    return nothing  # fallthrough
 end
 
 #=============================================================================
@@ -205,31 +224,25 @@ single-entry (post `normalize_cf`)."""
 function _both_arms_diverge(ctx::StructurizeCtx, current::Int, true_dest::Int,
                             false_dest::Int, then_blocks::Set{Int}, else_blocks::Set{Int},
                             region_blocks::Set{Int}, loop_ctx::Union{Nothing, LoopCtx})
-    entries, _ = branch_continuation(ctx, current, true_dest, false_dest,
+    entries, _ = branch_continuation(ctx.cfg, ctx.domtree, current, true_dest, false_dest,
                                      then_blocks, else_blocks, region_blocks, loop_ctx)
     return isempty(entries)
 end
 
 """
-    emit_branch!(block, ctx, current, gotoifnot, region_blocks, outer_merge_phis) -> next
+    emit_branch!(block, ctx, current, condbr, region_blocks, outer_merge_phis) -> next
 
 Create an IfOp for a conditional branch. Returns the merge block index to
 continue with, or nothing if both branches exit/diverge.
 """
 function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
-                      gotoifnot::GotoIfNot, region_blocks::Set{Int},
+                      condbr::MCondBr, region_blocks::Set{Int},
                       outer_merge_phis::Union{Nothing, Vector{MergePhiInfo}},
                       loop_ctx::Union{Nothing, LoopCtx}=nothing)
-    ir = ctx.ir
-    nblocks = length(ir.cfg.blocks)
-
-    # GotoIfNot: cond=false → dest, cond=true → fallthrough
-    false_dest = gotoifnot.dest
-    # Derive fallthrough from CFG successors (not current+1, which assumes sequential layout)
-    bb_succs = ir.cfg.blocks[current].succs
-    true_dest = length(bb_succs) == 1 ? only(bb_succs) :
-                first(s for s in bb_succs if s != false_dest)
-    cond = remap_ssa_ref(gotoifnot.cond, ctx.ssa_remap)
+    # MCondBr carries explicit true/false edges (no fallthrough/succ derivation).
+    true_dest = condbr.t.target
+    false_dest = condbr.f.target
+    cond = remap_ssa_ref(condbr.cond, ctx.ssa_remap)
 
     # Determine branch regions and merge block using dominance + exclusion.
     # A multi-entry continuation (the short-circuit shape `if a||b { body }`,
@@ -239,38 +252,35 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
     # diverge (zero continuation edges). The lift therefore has one branch path —
     # no shape-matching (`find_gated_body` is gone; invariant I4).
     then_blocks, else_blocks, merge = find_branch_regions(
-        ctx, current, true_dest, false_dest, region_blocks, loop_ctx)
+        ctx.cfg, ctx.domtree, current, true_dest, false_dest, region_blocks, loop_ctx)
     @assert merge !== nothing || _both_arms_diverge(ctx, current, true_dest, false_dest,
                                                     then_blocks, else_blocks, region_blocks, loop_ctx) """
         multi-entry continuation reached the lift at BB$current — normalize_cf's \
         continuation multiplexer should have collapsed it (internal error)"""
 
-    # If merge exists and is in region, extract its phis.
-    # Skip phis at loop headers — UNLESS the header has multiple non-loop predecessors
-    # (entry multiplexer case: branch must yield the correct entry values).
-    # Only extract multi-entry header phis OUTSIDE the loop (for the entry IfOp).
-    # Inside the loop, the header is reached via the latch (single back-edge) → ContinueOp.
+    # If merge exists and is in region, extract its block args (the "phis").
+    # Skip args at loop headers — UNLESS the header has multiple non-loop predecessors
+    # (entry multiplexer case: the branch must yield the correct entry values).
     is_multi_entry_header = if merge !== nothing && haskey(ctx.loop_map, merge) &&
                                loop_ctx === nothing  # not inside a loop
         loop_body = ctx.loop_map[merge]
-        count(p -> p ∉ loop_body, ir.cfg.blocks[merge].preds) > 1
+        count(p -> p ∉ loop_body, ctx.cfg.blocks[merge].preds) > 1
     else
         false
     end
-    # Continuation-by-exclusion finds the *real* merge directly, so a phi-free
-    # merge is genuinely phi-free: the walk continues through it without a
-    # separate pass-through "absorption" step (D-absorb retired). A no-phi merge
-    # yields `nothing` here → the "merge exists but no phis" path below.
+    # Continuation-by-exclusion finds the *real* merge directly, so a no-arg merge
+    # is genuinely arg-free: the walk continues through it without a separate
+    # pass-through step. A no-arg merge yields `nothing` here.
     merge_phis = if merge !== nothing && merge ∈ region_blocks &&
                    (!haskey(ctx.loop_map, merge) || is_multi_entry_header)
-        phis = extract_merge_phis(ir, merge, region_blocks)
+        phis = extract_merge_phis(ctx, merge, region_blocks)
         isempty(phis) ? nothing : phis
     else
         nothing
     end
 
-    # Determine what to pass as exit phis to sub-regions
-    # If both branches exit our region, they need to yield outer_merge_phis
+    # What to pass as exit phis to sub-regions: if both branches exit our region,
+    # they need to yield outer_merge_phis.
     sub_merge_phis = if merge !== nothing && merge ∈ region_blocks
         merge_phis  # yield inner merge phis
     else
@@ -282,23 +292,23 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
         structurize_region!(ctx, true_dest, then_blocks;
                              merge_phis=sub_merge_phis, loop_ctx=loop_ctx)
     else
-        make_empty_branch_block(true_dest, current, sub_merge_phis, loop_ctx, ir, ctx)
+        make_empty_branch_block(ctx, true_dest, current, sub_merge_phis, loop_ctx)
     end
 
     else_blk = if !isempty(else_blocks)
         structurize_region!(ctx, false_dest, else_blocks;
                              merge_phis=sub_merge_phis, loop_ctx=loop_ctx)
     else
-        make_empty_branch_block(false_dest, current, sub_merge_phis, loop_ctx, ir, ctx)
+        make_empty_branch_block(ctx, false_dest, current, sub_merge_phis, loop_ctx)
     end
 
-    # Anchor for debug info: use the branch terminator's location
-    branch_anchor = last(ir.cfg.blocks[current].stmts)
+    # Anchor for debug info: the branch condition (the block's last body stmt).
+    branch_anchor = last_body_id(ctx, current)
 
     if merge !== nothing && merge ∈ region_blocks && merge_phis !== nothing
         # --- Inner merge exists: standard IfOp ---
-        set_branch_yields!(then_blk, merge_phis, then_blocks, current, ir, block, ctx)
-        set_branch_yields!(else_blk, merge_phis, else_blocks, current, ir, block, ctx)
+        set_branch_yields!(then_blk, merge_phis, then_blocks, current, ctx)
+        set_branch_yields!(else_blk, merge_phis, else_blocks, current, ctx)
 
         if_op = IfOp(cond, then_blk, else_blk)
         phi_indices = [p.ssa_idx for p in merge_phis]
@@ -306,7 +316,7 @@ function emit_branch!(block::Block, ctx::StructurizeCtx, current::Int,
         emit_ifop_result!(block, if_op, phi_indices, phi_types, ctx, branch_anchor)
         return merge
     elseif merge !== nothing && merge ∈ region_blocks
-        # Merge exists but no phis
+        # Merge exists but no args
         set_yield_if_needed!(then_blk)
         set_yield_if_needed!(else_blk)
         if_op = IfOp(cond, then_blk, else_blk)
@@ -364,13 +374,13 @@ end
 """Set yield terminator on a branch block for merge phis, if not already set."""
 function set_branch_yields!(blk::Block, merge_phis::Vector{MergePhiInfo},
                             branch_blocks::Set{Int}, branch_entry::Int,
-                            ir::IRCode, parent_block::Block, ctx::StructurizeCtx)
+                            ctx::StructurizeCtx)
     blk.terminator !== nothing && return  # already set (e.g., ReturnNode, inner yield)
 
     # Find the exit block: the block in branch_blocks (or branch_entry if empty)
-    # that has an edge to a merge phi predecessor
-    exit_block = find_exit_predecessor(merge_phis, branch_blocks, branch_entry, ir)
-    blk.terminator = make_yield_for_edge(ir, merge_phis, exit_block, blk, ctx)
+    # whose edge feeds the merge phis.
+    exit_block = find_exit_predecessor(merge_phis, branch_blocks, branch_entry)
+    blk.terminator = make_yield_for_edge(merge_phis, exit_block, blk, ctx)
 end
 
 function set_yield_if_needed!(blk::Block)
@@ -378,79 +388,43 @@ function set_yield_if_needed!(blk::Block)
 end
 
 """Create an empty branch block with appropriate terminator for its destination."""
-function make_empty_branch_block(dest::Int, from::Int,
+function make_empty_branch_block(ctx::StructurizeCtx, dest::Int, from::Int,
                                   merge_phis::Union{Nothing, Vector{MergePhiInfo}},
-                                  loop_ctx::Union{Nothing, LoopCtx},
-                                  ir::IRCode, ctx::StructurizeCtx)
+                                  loop_ctx::Union{Nothing, LoopCtx})
     b = Block()
     # Loop boundary (continue / break)?
     if loop_ctx !== nothing && resolve_loop_exit!(b, ctx, dest, loop_ctx)
         return b
     end
-    # Merge phis? Use reachability from dest to find the right phi-edge value and
-    # yield it directly. Multi-entry continuations (the short-circuit `&&`/`||`
-    # shape, where a value is defined in a block between the arms and the merge)
-    # were collapsed to single-entry upstream by `normalize_cf`'s continuation
-    # multiplexer, so the value is always visible here — no tail duplication.
+    # Merge phis? Find the phi-edge value this empty arm contributes and yield it.
     if merge_phis !== nothing && !isempty(merge_phis)
-        pred = find_exit_predecessor(merge_phis, Set{Int}([dest]), from, ir)
-        b.terminator = make_yield_for_edge(ir, merge_phis, pred, b, ctx)
+        pred = find_exit_predecessor(merge_phis, Set{Int}([dest]), from)
+        b.terminator = make_yield_for_edge(merge_phis, pred, b, ctx)
     end
     return b
 end
 
 """
-    find_exit_predecessor(merge_phis, blocks, fallback, ir)
+    find_exit_predecessor(merge_phis, blocks, fallback)
 
-Find the block whose edge to the merge carries the phi value for this branch.
-Uses BFS from the branch region through successors (DREAM's reachability
-principle: the value a branch contributes to a merge phi is determined by
-which phi edge predecessor is reachable from that branch).
+The predecessor of the merge whose edge carries this branch's values: the arm
+block (in `blocks`) that directly feeds the merge, else the branch source
+`fallback`. Single-entry continuations (post `normalize_cf`) guarantee the arm's
+exit block is a *direct* merge predecessor — its terminator edge targets the merge
+— so a seed/fallback lookup suffices; no reachability search (the old pass-through
+BFS dissolved on the block-arg / edge-operand form).
 """
 function find_exit_predecessor(merge_phis::Vector{MergePhiInfo}, blocks::Set{Int},
-                                fallback::Int, ir::IRCode)
-    nblocks = length(ir.cfg.blocks)
+                                fallback::Int)
     seeds = isempty(blocks) ? Set{Int}([fallback]) : blocks
-
-    # Check seeds and fallback directly (before BFS)
     for b in seeds, phi in merge_phis
         haskey(phi.edge_values, b) && return b
     end
-    for phi in merge_phis
-        haskey(phi.edge_values, fallback) && return fallback
-    end
-
-    # BFS through successors of seeds (handles pass-through blocks)
-    visited = copy(seeds)
-    push!(visited, fallback)  # don't re-enter the branch source
-    queue = Int[]
-    for b in seeds
-        1 <= b <= nblocks || continue
-        for succ in ir.cfg.blocks[b].succs
-            succ ∈ visited || push!(queue, succ)
-        end
-    end
-
-    while !isempty(queue)
-        b = popfirst!(queue)
-        b ∈ visited && continue
-        push!(visited, b)
-
-        for phi in merge_phis
-            haskey(phi.edge_values, b) && return b
-        end
-
-        1 <= b <= nblocks || continue
-        for succ in ir.cfg.blocks[b].succs
-            succ ∈ visited || push!(queue, succ)
-        end
-    end
-
     return fallback
 end
 
 """Create a YieldOp with values from merge phis for a given predecessor edge."""
-function make_yield_for_edge(ir::IRCode, merge_phis::Vector{MergePhiInfo},
+function make_yield_for_edge(merge_phis::Vector{MergePhiInfo},
                               pred::Int, blk::Block, ctx::StructurizeCtx)
     yield_values = IRValue[]
     remap = ctx.ssa_remap
@@ -473,10 +447,10 @@ region reaches and yield that value. Multi-entry continuations (short-circuit
 `&&`/`||`) were collapsed to single-entry upstream by `normalize_cf`, so the
 yield value is always visible — no tail duplication.
 """
-function set_exit_yield!(blk::Block, ir::IRCode, ctx::StructurizeCtx,
+function set_exit_yield!(blk::Block, ctx::StructurizeCtx,
                           merge_phis::Vector{MergePhiInfo}, last_block::Int)
-    pred = find_exit_predecessor(merge_phis, Set{Int}([last_block]), last_block, ir)
-    blk.terminator = make_yield_for_edge(ir, merge_phis, pred, blk, ctx)
+    pred = find_exit_predecessor(merge_phis, Set{Int}([last_block]), last_block)
+    blk.terminator = make_yield_for_edge(merge_phis, pred, blk, ctx)
     return blk.terminator
 end
 

--- a/src/unstructurize.jl
+++ b/src/unstructurize.jl
@@ -622,9 +622,9 @@ end
 
 Assemble a dense `IRCode` from flat statement arrays plus per-block statement
 ranges. Builds the CFG (preds/succs from each block's last statement), the
-`InstructionStream`, and the debug info, then constructs the `IRCode`. Shared by
-`assemble_ircode` (unstructurize) and `_assemble` (multiplex's `emit`) — the same
-`cfg.index` off-by-one (block 1 excluded) was once fixed in both, proof of drift.
+`InstructionStream`, and the debug info, then constructs the `IRCode`. Used by
+`assemble_ircode` — the SCI → IRCode output boundary (the test-only roundtrip
+oracle; cuTile consumes the `StructuredIRCode` directly).
 """
 function build_dense_ircode(all_stmts, all_types, all_flags, line, bb_ranges;
                             argtypes, sptypes, debuginfo)

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -1718,17 +1718,6 @@ end
     @test moved_pos < if_pos
 end
 
-@testset "stmt_ssa_uses sees PiNode operand" begin
-    # A `PiNode`'s refined value is a real use. Missing it lets a post-loop
-    # type-assertion on a loop-internal SSA escape detection, so the value is
-    # never threaded out as a loop result → an out-of-scope reference in a
-    # sibling region. (Regression: AcceleratedKernels' nd-reduction kernel.)
-    @test collect(IRStructurizer.stmt_ssa_uses(Core.PiNode(SSAValue(7), Int))) ==
-          [SSAValue(7)]
-    # A PiNode over a non-SSA value (e.g. an Argument) contributes no SSA use.
-    @test isempty(collect(IRStructurizer.stmt_ssa_uses(Core.PiNode(Core.Argument(2), Int))))
-end
-
 @testset "operands dispatches on IR types" begin
     # PiNode
     pi = Core.PiNode(SSAValue(1), Int)

--- a/test/multiplex.jl
+++ b/test/multiplex.jl
@@ -1,15 +1,16 @@
 #=============================================================================
  Mutate-then-lift CFG normalization (src/structurize/multiplex.jl).
 
- M1 foundation: the explicit-edge mutable form (`ingest`/`emit`) must rebuild an
- IRCode that is faithful enough to (a) execute identically and (b) re-structurize
- identically — `emit(ingest(ir))` is the no-mutation identity that M2/M3 build on.
- The EdgeMultiplexer unit tests then check the mux primitive on synthetic
- multi-entry CFGs.
+ The structurizer works on the explicit-edge `MCFG` (`ingest` from IRCode, lift to
+ SCI via `lift_mcfg`) — there is no dense round-trip. These tests exercise the
+ `EdgeMultiplexer` primitive directly on synthetic multi-entry CFGs: mux the
+ distinct targets, then lift + execute and check the result. End-to-end mux
+ coverage (short-circuits, irreducible headers, multi-exit loops) lives in the
+ regression suite and the loop fuzzer.
 =============================================================================#
 
 const CCx = Core.Compiler
-using IRStructurizer: ingest, emit, MCFG, MBlock, MEdge, MGoto, MCondBr, MReturn,
+using IRStructurizer: ingest, lift_mcfg, MCFG, MBlock, MEdge, MGoto, MCondBr, MReturn,
                       EdgeRef, single_entry_mux!, edge_of
 using Core: Argument, GotoNode, GotoIfNot, ReturnNode, PhiNode, SSAValue
 
@@ -23,97 +24,10 @@ function exec_ir(ir, args...)
     return Core.OpaqueClosure(ir)(args...)
 end
 
-# emit(ingest(ir)) executes identically to direct call.
-function rt_identity(f, args...)
-    ir, _ = only(code_ircode(f, Tuple{map(typeof, args)...}))
-    ir2 = emit(ingest(ir))
-    got = exec_ir(ir2, args...)
-    exp = f(args...)
-    return got == exp || got === exp
-end
-
-# emit(ingest(ir)) re-structurizes (+validates) and executes identically.
-function rt_restructure(f, args...)
-    ir, _ = only(code_ircode(f, Tuple{map(typeof, args)...}))
-    ir2 = emit(ingest(ir))
-    sci = StructuredIRCode(ir2)                    # structurize + validate
-    got = execute(sci, args...)
-    exp = f(args...)
-    return got == exp || got === exp
-end
-
-@noinline _opaque(b) = Base.compilerbarrier(:type, b)::Bool
-@noinline _sink(x) = (Base.donotdelete(x); nothing)
-
-# Representative CFG shapes spanning the corpus families. Each entry is
-# (function, args-tuple); checked under both round-trip lenses.
-function _corpus_cases()
-    cases = Any[]
-    push!(cases, (x -> x > 0 ? x + 1 : x - 1, (5,)))
-    push!(cases, (x -> x > 0 ? x + 1 : x - 1, (-3,)))
-    push!(cases, (x -> x > 0 ? x : -x, (7,)))
-    push!(cases, ((x::Int, y::Int) -> (r = 0; if x > 0 || y > 0; r = 1; end; r), (1, -1)))
-    push!(cases, ((x::Int, y::Int) -> (r = 0; if x > 0 && y > 0; r = 1; end; r), (1, 1)))
-    let f = (x, y, z) -> (a = (x > 0 && y > 0) ? x * y : (z > 0 ? z + 1 : -z); a + 100)
-        for args in ((1,1,1), (-1,1,1), (1,-1,1), (-1,-1,-1)); push!(cases, (f, args)); end
-    end
-    push!(cases, (n -> (acc = 0; for i in 1:n; acc += i; end; acc), (5,)))
-    push!(cases, (n -> (i = 0; while i < n; i += 1; end; i), (5,)))
-    push!(cases, (n -> (acc = 0; for i in 1:2:n; acc += i; end; acc), (7,)))
-    let f = (n::Int, mq::Int) -> (s = 0; for i in 1:n, j in 1:mq; s += i*j; end; s)
-        push!(cases, (f, (3, 4)))
-    end
-    let f = (n::Int, c::Bool) -> (cond = _opaque(c); acc = 0;
-            for kt in 1:n; if cond; _sink(kt); end; if cond; acc += kt; end; end; acc)
-        push!(cases, (f, (5, true))); push!(cases, (f, (5, false)))
-    end
-    function loop_throw(a::Vector{Float32}, n::Int)
-        acc = 0.0f0
-        for k in 1:n; x = @inbounds a[k]; x < 0.0f0 && throw(DomainError(x)); acc += x; end
-        return acc
-    end
-    push!(cases, (loop_throw, (Float32[1,2,3], 3)))
-    function ret_in_loop(v::Vector{Int}, n::Int)
-        acc = 0; for i in 1:n; v[i] < 0 && return -i; acc += v[i]; end; return acc
-    end
-    push!(cases, (ret_in_loop, (Int[1,2,3], 3))); push!(cases, (ret_in_loop, (Int[1,-2,3], 3)))
-    function ret_and_throw(v::Vector{Int}, n::Int)
-        s = 0; for i in 1:n; v[i] == 0 && throw(DomainError(i)); v[i] < 0 && return -i; s += v[i]; end; return s
-    end
-    push!(cases, (ret_and_throw, (Int[1,2,3], 3)))
-    function gated_loop_acc(c::Bool, v::Vector{Int}, n::Int)
-        s = 0; for k in 1:n; if _opaque(c) || k > 2; s += (k == 1) ? v[k] : v[k] + 100; end; end; return s
-    end
-    push!(cases, (gated_loop_acc, (true, [1,2,3], 3))); push!(cases, (gated_loop_acc, (false, [5,6,7,8], 4)))
-    function pi_carry(v::Vector{Any}, n::Int)
-        x = 0; for i in 1:n; x = v[i]::Int; end; return x + 1
-    end
-    push!(cases, (pi_carry, (Any[1,2,3], 3)))
-    return cases
-end
+# Lift a (manually muxed) MCFG to an SCI and execute it (build_ir comes from setup.jl).
+mux_exec(m, args...) = exec_ir(CCx.IRCode(lift_mcfg(m)), args...)
 
 @testset "multiplex (mutate-then-lift)" begin
-
-@testset "ingest/emit round-trip identity" begin
-    for (f, args) in _corpus_cases()
-        @test rt_identity(f, args...)
-        @test rt_restructure(f, args...)
-    end
-end
-
-@testset "emit produces a well-formed CFG index" begin
-    # `CFG.index` lists the first statement of blocks 2..n (length n-1), excluding
-    # block 1 — an off-by-one here makes `block_for_inst` mis-map every statement.
-    for (f, args) in _corpus_cases()
-        ir, _ = only(code_ircode(f, Tuple{map(typeof, args)...}))
-        ir2 = emit(ingest(ir))
-        @test length(ir2.cfg.index) == length(ir2.cfg.blocks) - 1
-        @test ir2.cfg.index == [first(b.stmts) for b in ir2.cfg.blocks[2:end]]
-    end
-end
-
-# Structurize a muxed IRCode and execute it (build_ir comes from corpus.jl).
-mux_exec(m, args...) = exec_ir(CCx.IRCode(StructuredIRCode(emit(m))), args...)
 
 @testset "EdgeMultiplexer" begin
     @testset "2-entry continuation (short-circuit shape)" begin

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -637,4 +637,50 @@ end
     end
 end
 
+@testset "branch-selected init read after the loop (pre-header)" begin
+    # An if/else (not a ternary) writes a variable whose SSA phi sits at the loop
+    # header — the branch's merge block *is* the loop header — and the variable is
+    # read after the loop. Without the pre-header (normalize_one_preheader!) the
+    # read saw the *entry* value (the branch selection), not the loop result: the
+    # IfOp parked the entry value at the header phi id and the loop result at a
+    # fresh id, but post-loop uses still referenced the header phi id. The
+    # pre-header routes the entry edges through a separate block so the IfOp yields
+    # into the pre-header args (the loop init) while the loop result stays on the
+    # header arg — the value `return`ed. Silent miscompile before the fix
+    # (ISSUES.md #2, "meh1"); the standing fuzzers use ternary inits and missed it.
+    function meh1(c::Bool, n::Int)
+        if c; x = 10; else; x = 100; end   # if-merge coincides with the while header
+        while x < n; x += 1; end
+        return x
+    end
+    # The pre-header fix lives in the core lift, so assert it there across every n —
+    # including the empty-loop cases (init already ≥ bound) where the result is the
+    # branch selection (10/100) itself. (A separate, pre-existing *promotion* bug
+    # miscompiles an empty counted while-loop, returning the bound instead of the
+    # init — ISSUES.md #3 — so the empty case is asserted at promote=false here.)
+    ir_np, _ = only(code_ircode(meh1, Tuple{Bool, Int}))
+    sci_np = StructuredIRCode(ir_np; promote=false)
+    for c in (false, true), n in (0, 5, 50, 200)
+        @test execute(sci_np, c, n) == meh1(c, n)
+    end
+    # The literal ISSUES.md #2 repro through the full pipeline: at n=200 the loop
+    # runs for both arms, so the result is the loop output (200), not the entry
+    # value (10/100) — the miscompile the pre-header closed.
+    sci, _ = code_structured(meh1, Tuple{Bool, Int}) |> only
+    @test execute(sci, true, 200) == 200
+    @test execute(sci, false, 200) == 200
+
+    # Counted-for outer loop carrying a branch-selected accumulator (the loop runs
+    # `1:n` independent of the init, so promotion is well-behaved here).
+    function meh_for(c::Bool, n::Int)
+        if c; s = 10; else; s = 100; end
+        for _ in 1:n; s += 1; end
+        return s
+    end
+    sci2, _ = code_structured(meh_for, Tuple{Bool, Int}) |> only
+    for c in (false, true), n in (0, 1, 5)
+        @test execute(sci2, c, n) == meh_for(c, n)
+    end
+end
+
 end  # regression suite

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -36,10 +36,10 @@
     end
 
     ir = q1_ir()
-    ctx = IRStructurizer.StructurizeCtx(ir)
+    domtree = Core.Compiler.construct_domtree(ir)
     region = Set(1:length(ir.cfg.blocks))
     then_blocks, else_blocks, merge =
-        IRStructurizer.find_branch_regions(ctx, 1, 2, 3, region)  # E: true=BB2, false=BB3
+        IRStructurizer.find_branch_regions(ir.cfg, domtree, 1, 2, 3, region)  # E: true=BB2, false=BB3
     @test merge == 2                       # T is the continuation
     @test !(2 in then_blocks)              # ...not swallowed into an arm
     @test !(2 in else_blocks)
@@ -83,10 +83,10 @@ end
 
     for m_first in (false, true)
         ir, m_bb = q2_ir(; m_first)
-        ctx = IRStructurizer.StructurizeCtx(ir)
+        domtree = Core.Compiler.construct_domtree(ir)
         region = Set(1:length(ir.cfg.blocks))
         fdest = (ir.stmts.stmt[ir.cfg.blocks[1].stmts[end]]::GotoIfNot).dest
-        _, _, merge = IRStructurizer.find_branch_regions(ctx, 1, 2, fdest, region)
+        _, _, merge = IRStructurizer.find_branch_regions(ir.cfg, domtree, 1, 2, fdest, region)
         @test merge == m_bb                # M chosen regardless of its index
 
         sci = StructuredIRCode(q2_ir(; m_first)[1])

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -10,7 +10,7 @@ function build_ir(blocks::Vector, argtypes::Vector)
     # Build the InstructionStream from flat vectors via its bulk constructor.
     # The per-statement `Instruction` proxy with `inst[:field] = ...` only exists
     # on 1.12+, whereas this constructor (and the 3-per-stmt packed `line`) is
-    # shared, matching production `_assemble`.
+    # shared, matching production `build_dense_ircode`.
     all_stmts = Vector{Any}(undef, nstmts)
     all_types = Vector{Any}(undef, nstmts)
     all_flags = fill(CC.IR_FLAGS_EFFECTS, nstmts)


### PR DESCRIPTION
Converges the structurizer on MLIR's `CFGToSCF` along two axes and removes ~220 lines net. The
*representation* becomes MLIR-shaped: a single explicit-edge `MBlock`/`MCFG` form (block arguments +
per-edge operands), ingested once from `IRCode` and lifted straight to the `StructuredIRCode`, with
the dense `emit` round-trip deleted. The *algorithm* becomes MLIR-shaped: loop headers gain a
pre-header in the mutate phase, and `IfOp` merge values are read from each arm's own edge. The
pre-header change also fixes a silent miscompile.

## What changed

**One working representation, no round-trip.**
The mutable CFG used to be a transient: ingest (IRCode → MCFG) → mutate → emit (MCFG → IRCode) →
re-derive the dominator tree and natural loops over the dense IRCode → lift. It is now the single
working form: ingest once → one mutate fixpoint over the MCFG → the lift reads the `MBlock` form
directly. `emit` and its whole dense-rebuild support (block layout, the clone-for-emit family,
trampoline emission) are gone; the lift's context holds the MCFG; merge and loop handling read block
arguments + per-edge operands instead of phi nodes. Ingest (in) and `unstructurize` (test-only, out)
are the only conversions left.

**Pre-header for multi-entry loop headers.**
A loop header reached by more than one entry edge is also a branch merge. It is now routed through a
single pre-header in the mutate phase (the equivalent of MLIR's loop-parent block), so a header is
never a branch merge: the preceding `if`/`else`'s continuation is the pre-header, whose arguments take
the merged entry value and feed the loop init, while loop results stay on the header's own arguments.
This lets the lift's last CFG-shape-keyed branch and two special-case casings in the loop lift be
deleted. It also fixes a silent miscompile where a branch-selected value feeding a loop and read after
it returned the branch's *entry* value rather than the loop result — e.g.
`if c; x = 10; else; x = 100; end; while x < n; x += 1; end; return x` returned `10`/`100` instead of
the loop's output. A regression test is added.

**Merge values read from each arm's own edge.**
The predecessor-keyed phi dictionary and its reverse lookup are replaced by reading the merge block's
result shape once and having each arm yield the operands its own exit edge carries to the merge. Same
behavior, less machinery (net −41 lines).