### PR TITLE
Fix silent miscompile of counted loops whose induction variable escapes

### DIFF
--- a/src/structurize/promote.jl
+++ b/src/structurize/promote.jl
@@ -61,11 +61,11 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                     result2, removed2 = try_promote_for(promoted, idx, block, new_body, ctx)
                     if result2 isa ForOp
                         if isempty(removed2)
-                            # IV kept as an ordinary carry because it escapes (PLAN7
-                            # Phase 1): arity/order are unchanged, so post-loop
-                            # getfields read it directly — no for_promotions entry and
-                            # no getfield rewrite. The empty-case value comes out right
-                            # for free from carried-value semantics (empty ⇒ init).
+                            # The escaping IV is kept as an ordinary carry, so the
+                            # arity and order are unchanged and post-loop getfields
+                            # read it directly. No for_promotions entry, no getfield
+                            # rewrite. Carried-value semantics give the empty-loop
+                            # case its init, which is the value we want there.
                             push!(new_body, (idx, result2, entry.type, entry.flag))
                         else
                             for_promotions[idx] = (removed2, result2, Dict{Int,Int}())
@@ -93,11 +93,11 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                     new_gf = Expr(:call, Core.getfield, SSAValue(loop_ssa), adjusted)
                     push!(new_body, (idx, new_gf, entry.type, entry.flag))
                 else
-                    # `upper` alias for a removed IV/shadow position. Since PLAN7
-                    # keeps every *escaping* removed position as a real carry, this
-                    # branch is reachable only for a provably-dead getfield (the
-                    # IV-escape gate returned false), so the alias is never observed.
-                    @assert !_ssa_used_in_block(SSAValue(idx), idx, block) "escaping removed position aliased to upper (PLAN7 invariant violated)"
+                    # `upper` alias for a removed IV/shadow position. Every escaping
+                    # removed position is kept as a real carry instead, so this branch
+                    # is only reachable for a provably-dead getfield (the IV-escape
+                    # check returned false) and the alias is never observed.
+                    @assert !_ssa_used_in_block(SSAValue(idx), idx, block) "escaping removed position aliased to upper"
                     push!(new_body, (idx, for_op.upper, entry.type, entry.flag))
                 end
             else
@@ -252,17 +252,15 @@ function simplify_loop_exit(body::Block)
     return result
 end
 
-"""Does a post-loop read of the loop result's `pos`-th field survive in the parent
-block? A `ForOp` does not carry its induction variable as a result — it is implicit
-in the range — so `promote_loops!` aliases any post-loop `getfield` at the IV
-position to the loop's exclusive `upper` bound. That alias equals the final IV only
-when the loop body ran (`for i in lo:hi` exits with `i == hi`); for an *empty* loop
-(init ≥ bound, zero trips) the final IV is the **init** (`lower`), not `upper`, so
-the alias silently returns the bound (ISSUES.md #3). When the IV escapes we must
-therefore *not* promote to `ForOp`; the `WhileOp` form carries the IV as a genuine
-result and stays correct for the empty case. A true counted `for i in lo:hi` never
-reads `i` after the loop (Julia scopes it), so this gate does not demote real
-counted loops — only `while`-shaped loops whose tested value is read afterwards."""
+"""Is the loop result's `pos`-th field read anywhere in the parent block? A `ForOp`
+does not carry its induction variable as a result; the IV is implicit in the range.
+Promotion can drop the IV carry and serve a post-loop `getfield` at that position
+from the exclusive `upper` bound, but `upper` equals the final IV only when the body
+ran at least once. An empty (zero-trip) loop leaves the IV at its init (`lower`), so
+the `upper` alias is wrong there. Callers use this per position to decide whether to
+keep an escaping IV or shadow as a real carry (read back normally) or to drop it
+(safe only when no live read remains). A genuine counted `for i in lo:hi` never reads
+`i` afterwards, since Julia scopes it out, so a counted loop is unaffected."""
 function loop_result_pos_escapes(loop_idx::Int, pos::Int, parent_block::Block)
     for (pidx, pentry) in parent_block.body
         s = pentry.stmt
@@ -470,13 +468,13 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
         _ssa_used_in_block(SSAValue(gf_idx), gf_idx, parent_block) && return (loop, Int[], Dict{Int,Int}())
     end
 
-    # IV-escape gate (ISSUES.md #3 / PLAN7 Phase 2): removed positions (the IV and
-    # its value#1 shadows) would otherwise be aliased to `upper` post-loop — wrong
-    # for an empty loop, whose final IV is the init. Rather than decline the whole
-    # promotion, *partition* `removed`: any escaping position becomes a real kept
-    # carry (read back normally), while the rest stay removed (their `upper` alias
-    # is then provably dead). Duplicate-carry redirects stay removed (an Undef-init
-    # dup is not a meaningful escaping value; it is folded into its survivor).
+    # Partition `removed` by whether each position escapes. A removed position (the
+    # IV or one of its value#1 shadows) would otherwise be aliased to `upper`
+    # post-loop, which is wrong for an empty loop whose final IV is the init. So any
+    # escaping position becomes a real kept carry (read back normally) and the rest
+    # stay removed (their `upper` alias is then provably dead). A duplicate-carry
+    # redirect stays removed; an Undef-init dup is folded into its survivor, not a
+    # value that escapes on its own.
     kept = Int[]
     for r in removed
         haskey(carry_redirect, r) && continue
@@ -504,12 +502,12 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
         arg_remap[body.args[r].id] = iv_arg
     end
 
-    # Retained carries — genuine carries AND kept escaping IV/shadows (no longer in
-    # `removed`) — get fresh BlockArguments in original index order, each with its
-    # own init. A kept escaping IV/shadow is the current IV *in-body* (e.g. the same
-    # value an `acc += i` reads), so its in-body uses must resolve to `iv_arg`; its
-    # fresh for-arg is then a write-only carry slot that only exposes the post-loop
-    # result. A genuine carry maps its body uses to its own for-arg as usual.
+    # Retained carries get fresh BlockArguments in original index order, each with
+    # its own init. This covers genuine carries and kept escaping IV/shadows (the
+    # latter are no longer in `removed`). A kept escaping IV/shadow holds the current
+    # IV in-body, e.g. the value an `acc += i` reads, so its in-body uses resolve to
+    # `iv_arg` and its fresh for-arg is a write-only carry slot that only exposes the
+    # post-loop result. A genuine carry maps its body uses to its own for-arg.
     non_iv_inits = IRValue[]
     for (i, arg) in enumerate(body.args)
         i ∈ removed && continue
@@ -524,13 +522,13 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
         arg_remap[body.args[dup_pos].id] = arg_remap[body.args[surv_pos].id]
     end
 
-    # ContinueOp values. A kept escaping position must carry `iv_arg` itself — NOT
-    # its lifted continue, which is the *advanced* value `iv+step` (the iterate
-    # protocol advances before re-checking, so that continue equals `upper`, the
+    # ContinueOp values. A kept escaping position carries `iv_arg` itself, not its
+    # lifted continue. The iterate protocol advances the state before re-checking, so
+    # the lifted continue is the advanced value `iv+step`, which equals `upper` (the
     # post-loop bound). Carrying `iv_arg` makes the kept carry's last value the last
-    # in-body IV (`upper − step`), matching the LoopOp's break (the pre-advance
-    # current value); the empty range is guarded by the outer `if`, so the init is
-    # only read when the loop ran (PLAN7 §3 — the research answer is wrong here).
+    # in-body IV (`upper - step`), matching the LoopOp's break, which is the
+    # pre-advance current value. The empty range is guarded by the outer `if`, so the
+    # init is read only when the loop ran.
     cont_values = IRValue[]
     for (i, v) in enumerate(continue_op.values)
         i ∈ removed && continue
@@ -540,7 +538,7 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
     # The IV increment (`step_ssa = iv + step`) is implicit in the range. Kept
     # carries reference `iv_arg`, not the increment, so the statement is needed only
     # if some other retained body stmt or surviving carried value reads it. Keep it
-    # iff referenced — a dead increment is harmless, a missing one dangles.
+    # only when referenced. A dead increment is harmless; a missing one dangles.
     last_idx = body.body.ssa_idxes[end]
     incr_used = false
     if step_ssa !== nothing
@@ -675,11 +673,12 @@ end
 Try to promote a WhileOp to ForOp by detecting counting patterns.
 Returns `(promoted_op, removed)` where `removed::Vector{Int}` lists the loop-result
 positions the ForOp dropped (the caller adjusts post-loop `getfield`s accordingly):
-- `(ForOp, [iv_pos])` — the IV was removed (the usual case; it is implicit in the range).
-- `(ForOp, Int[])` — the IV escapes, so it is **kept** as an ordinary carry (PLAN7
-  Phase 1): the result arity/order match the original WhileOp and the empty (zero-trip)
-  case reads back the init, not the bound. No position is removed.
-- `(op, Int[])` with `op` still a WhileOp — not promoted.
+- `(ForOp, [iv_pos])`: the IV was removed, the usual case, since it is implicit in
+  the range.
+- `(ForOp, Int[])`: the IV escapes, so it is kept as an ordinary carry. The result
+  arity and order match the original WhileOp, and the empty (zero-trip) case reads
+  back the init rather than the bound. No position is removed.
+- `(op, Int[])` with `op` still a WhileOp: not promoted.
 """
 function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
                           ctx::StructurizeCtx)
@@ -715,11 +714,10 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
     iv_pos = findfirst(a -> a.id == iv_candidate.id, before.args)
     iv_pos === nothing && return (op, Int[])
 
-    # IV-escape gate (ISSUES.md #3 / PLAN7): a ForOp does not carry its IV as a
-    # result. If the IV is read after the loop, do NOT drop it — keep it as an
-    # ordinary carry (`keep_iv`) so the post-loop read is a normal result, correct
-    # for both the empty (init) and non-empty (last continue = upper) cases. When
-    # the IV does not escape, drop it as before (it is redundant with the range).
+    # A ForOp does not carry its IV as a result. If the IV is read after the loop,
+    # keep it as an ordinary carry (`keep_iv`) so the post-loop read is a normal
+    # result, correct for both the empty (init) and non-empty (last continue = upper)
+    # cases. If the IV does not escape, drop it; it is redundant with the range.
     keep_iv = loop_result_pos_escapes(idx, iv_pos, parent_block)
 
     # Find step: look in the after region for add_int(iv_arg, step)
@@ -809,12 +807,12 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
     arg_remap[after_iv_arg.id] = iv_arg
     arg_remap[before_iv_arg.id] = iv_arg
 
-    # The IV increment (`carried_val = iv + step`) is implicit in a ForOp, so it
-    # is normally dropped. But if another body statement or a surviving carried
-    # value reads it — e.g. `s += k` where `k` is the post-increment IV, or the
-    # kept-IV carry whose continue *is* the increment — it must stay, remapped
-    # below to read the ForOp's induction variable; dropping it then left a
-    # dangling SSA reference (`%k used but not defined`).
+    # The IV increment (`carried_val = iv + step`) is implicit in a ForOp, so it is
+    # normally dropped. It must stay when something else reads it: another body
+    # statement (e.g. `s += k` where `k` is the post-increment IV), or the kept-IV
+    # carry whose continue is the increment. When kept it is remapped below to read
+    # the ForOp's induction variable; dropping it in that case leaves a dangling SSA
+    # reference (`%k used but not defined`).
     incr_used = keep_iv
     if !incr_used && carried_val isa SSAValue
         for (sidx, sentry) in after.body

--- a/src/structurize/promote.jl
+++ b/src/structurize/promote.jl
@@ -58,11 +58,20 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                 # Fall back to existing path: LoopOp → WhileOp → ForOp
                 promoted = try_promote_while(stmt, ctx)
                 if promoted !== nothing
-                    result2, iv_pos = try_promote_for(promoted, idx, block, new_body, ctx)
-                    if result2 isa ForOp && iv_pos > 0
-                        for_promotions[idx] = ([iv_pos], result2, Dict{Int,Int}())
-                        carry_types = Any[t for (i, t) in enumerate(entry.type.parameters) if i != iv_pos]
-                        push!(new_body, (idx, result2, Tuple{carry_types...}, entry.flag))
+                    result2, removed2 = try_promote_for(promoted, idx, block, new_body, ctx)
+                    if result2 isa ForOp
+                        if isempty(removed2)
+                            # IV kept as an ordinary carry because it escapes (PLAN7
+                            # Phase 1): arity/order are unchanged, so post-loop
+                            # getfields read it directly — no for_promotions entry and
+                            # no getfield rewrite. The empty-case value comes out right
+                            # for free from carried-value semantics (empty ⇒ init).
+                            push!(new_body, (idx, result2, entry.type, entry.flag))
+                        else
+                            for_promotions[idx] = (removed2, result2, Dict{Int,Int}())
+                            carry_types = Any[t for (i, t) in enumerate(entry.type.parameters) if i ∉ removed2]
+                            push!(new_body, (idx, result2, Tuple{carry_types...}, entry.flag))
+                        end
                     else
                         push!(new_body, (idx, result2, entry.type, entry.flag))
                     end
@@ -236,6 +245,29 @@ function simplify_loop_exit(body::Block)
     end
     push!(result.body, (outer_idx, merged_if, Tuple{}))
     return result
+end
+
+"""Does a post-loop read of the loop result's `pos`-th field survive in the parent
+block? A `ForOp` does not carry its induction variable as a result — it is implicit
+in the range — so `promote_loops!` aliases any post-loop `getfield` at the IV
+position to the loop's exclusive `upper` bound. That alias equals the final IV only
+when the loop body ran (`for i in lo:hi` exits with `i == hi`); for an *empty* loop
+(init ≥ bound, zero trips) the final IV is the **init** (`lower`), not `upper`, so
+the alias silently returns the bound (ISSUES.md #3). When the IV escapes we must
+therefore *not* promote to `ForOp`; the `WhileOp` form carries the IV as a genuine
+result and stays correct for the empty case. A true counted `for i in lo:hi` never
+reads `i` after the loop (Julia scopes it), so this gate does not demote real
+counted loops — only `while`-shaped loops whose tested value is read afterwards."""
+function loop_result_pos_escapes(loop_idx::Int, pos::Int, parent_block::Block)
+    for (pidx, pentry) in parent_block.body
+        s = pentry.stmt
+        s isa Expr || continue
+        s.head === :call && length(s.args) == 3 && s.args[1] === Core.getfield || continue
+        s.args[2] isa SSAValue && s.args[2].id == loop_idx || continue
+        s.args[3]::Int == pos || continue
+        _ssa_used_in_block(SSAValue(pidx), pidx, parent_block) && return true
+    end
+    return false
 end
 
 """Check if an SSA value is referenced in a block's body (after `after_idx`) or terminator."""
@@ -433,6 +465,16 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
         _ssa_used_in_block(SSAValue(gf_idx), gf_idx, parent_block) && return (loop, Int[], Dict{Int,Int}())
     end
 
+    # IV-escape gate (ISSUES.md #3): removed positions (the IV and its shadows) are
+    # aliased to `upper` post-loop — wrong for an empty loop, whose final IV is the
+    # init. If any such position (one that aliases to `upper`, i.e. not a duplicate
+    # carry redirected to a real carry) is read after the loop, keep the LoopOp.
+    # A genuine `for i in lo:hi` never reads its IV afterwards, so this stays inert.
+    for r in removed
+        haskey(carry_redirect, r) && continue
+        loop_result_pos_escapes(idx, r, parent_block) && return (loop, Int[], Dict{Int,Int}())
+    end
+
     # --- Build ForOp ---
     lower = loop.init_values[iv_pos]
     # For ===: body runs for iv = init...bound inclusive, exclusive upper = bound + step
@@ -587,25 +629,31 @@ end
 
 """
 Try to promote a WhileOp to ForOp by detecting counting patterns.
-Returns (promoted_op, iv_pos) where iv_pos > 0 if ForOp was created.
+Returns `(promoted_op, removed)` where `removed::Vector{Int}` lists the loop-result
+positions the ForOp dropped (the caller adjusts post-loop `getfield`s accordingly):
+- `(ForOp, [iv_pos])` — the IV was removed (the usual case; it is implicit in the range).
+- `(ForOp, Int[])` — the IV escapes, so it is **kept** as an ordinary carry (PLAN7
+  Phase 1): the result arity/order match the original WhileOp and the empty (zero-trip)
+  case reads back the init, not the bound. No position is removed.
+- `(op, Int[])` with `op` still a WhileOp — not promoted.
 """
 function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
                           ctx::StructurizeCtx)
-    op isa WhileOp || return (op, 0)
+    op isa WhileOp || return (op, Int[])
 
     # Look for: condition is slt_int/sle_int on a block arg vs loop-invariant bound
     before = op.before
-    before.terminator isa ConditionOp || return (op, 0)
+    before.terminator isa ConditionOp || return (op, Int[])
     cond_op = before.terminator
 
     # Find the condition expression
     cond_val = cond_op.condition
-    cond_val isa SSAValue || return (op, 0)
+    cond_val isa SSAValue || return (op, Int[])
     cond_entry = get(before.body, cond_val.id, nothing)
-    cond_entry === nothing && return (op, 0)
+    cond_entry === nothing && return (op, Int[])
     cond_expr = cond_entry.stmt
-    cond_expr isa Expr && cond_expr.head === :call || return (op, 0)
-    length(cond_expr.args) >= 3 || return (op, 0)
+    cond_expr isa Expr && cond_expr.head === :call || return (op, Int[])
+    length(cond_expr.args) >= 3 || return (op, Int[])
 
     func = cond_expr.args[1]
     iv_candidate = cond_expr.args[2]
@@ -614,18 +662,25 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
     # Check condition function (=== is not a counting pattern; handled by Path A)
     is_slt = func isa GlobalRef && func.name in (:slt_int, :ult_int)
     is_sle = func isa GlobalRef && func.name === :sle_int
-    (is_slt || is_sle) || return (op, 0)
+    (is_slt || is_sle) || return (op, Int[])
 
     # IV must be a block argument
-    iv_candidate isa BlockArgument || return (op, 0)
+    iv_candidate isa BlockArgument || return (op, Int[])
 
     # Find IV's position in args
     iv_pos = findfirst(a -> a.id == iv_candidate.id, before.args)
-    iv_pos === nothing && return (op, 0)
+    iv_pos === nothing && return (op, Int[])
+
+    # IV-escape gate (ISSUES.md #3 / PLAN7): a ForOp does not carry its IV as a
+    # result. If the IV is read after the loop, do NOT drop it — keep it as an
+    # ordinary carry (`keep_iv`) so the post-loop read is a normal result, correct
+    # for both the empty (init) and non-empty (last continue = upper) cases. When
+    # the IV does not escape, drop it as before (it is redundant with the range).
+    keep_iv = loop_result_pos_escapes(idx, iv_pos, parent_block)
 
     # Find step: look in the after region for add_int(iv_arg, step)
     after = op.after
-    iv_pos <= length(after.args) || return (op, 0)
+    iv_pos <= length(after.args) || return (op, Int[])
     after_iv_arg = after.args[iv_pos]
     before_iv_arg = before.args[iv_pos]
 
@@ -648,19 +703,19 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
             end
         end
     end
-    step === nothing && return (op, 0)
+    step === nothing && return (op, Int[])
 
     # ForOp requires positive step (ascending loops only)
-    step isa Integer && step < 0 && return (op, 0)
+    step isa Integer && step < 0 && return (op, Int[])
 
     # Step must be loop-invariant (not defined inside the loop body)
     if step isa SSAValue && (haskey(op.after.body, step.id) || haskey(op.before.body, step.id))
-        return (op, 0)
+        return (op, Int[])
     end
 
     # Bound must be loop-invariant (not a block arg of this loop)
     if bound isa BlockArgument && any(a -> a.id == bound.id, before.args)
-        return (op, 0)
+        return (op, Int[])
     end
 
     # Build ForOp
@@ -678,11 +733,13 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
         upper = SSAValue(adj_ssa)
     end
 
-    # Non-IV init values
-    non_iv_inits = IRValue[]
+    # Carry init values. When the IV escapes (`keep_iv`) it rides as an ordinary
+    # carry, so its init (`lower`) is kept in place and the arity/order match the
+    # original WhileOp; otherwise the IV position is dropped (implicit in the range).
+    carry_inits = IRValue[]
     for (i, v) in enumerate(op.init_values)
-        i == iv_pos && continue
-        push!(non_iv_inits, v)
+        (i == iv_pos && !keep_iv) && continue
+        push!(carry_inits, v)
     end
 
     iv_arg = BlockArgument(alloc_arg!(ctx), iv_candidate.type)
@@ -691,13 +748,8 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
     for_body = Block()
     arg_remap = Dict{Int, BlockArgument}()
 
-    # Map after IV arg → ForOp's iv_arg
-    arg_remap[after_iv_arg.id] = iv_arg
-    # Also map before IV arg (in case of stale cross-scope refs)
-    arg_remap[before_iv_arg.id] = iv_arg
-
     for (i, arg) in enumerate(after.args)
-        i == iv_pos && continue
+        (i == iv_pos && !keep_iv) && continue
         for_arg = BlockArgument(alloc_arg!(ctx), arg.type)
         push!(for_body.args, for_arg)
         arg_remap[arg.id] = for_arg
@@ -707,13 +759,20 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
         end
     end
 
+    # In-body IV references always resolve to the implicit induction variable
+    # (`iv_arg`), overriding the write-only carry slot the kept-IV loop just mapped
+    # above: the kept carry is computed (continue = the increment) but never read.
+    arg_remap[after_iv_arg.id] = iv_arg
+    arg_remap[before_iv_arg.id] = iv_arg
+
     # The IV increment (`carried_val = iv + step`) is implicit in a ForOp, so it
-    # is normally dropped. But if another body statement or a surviving (non-IV)
-    # carried value reads it — e.g. `s += k` where `k` is the post-increment IV —
-    # it must stay, remapped below to read the ForOp's induction variable;
-    # dropping it then left a dangling SSA reference (`%k used but not defined`).
-    incr_used = false
-    if carried_val isa SSAValue
+    # is normally dropped. But if another body statement or a surviving carried
+    # value reads it — e.g. `s += k` where `k` is the post-increment IV, or the
+    # kept-IV carry whose continue *is* the increment — it must stay, remapped
+    # below to read the ForOp's induction variable; dropping it then left a
+    # dangling SSA reference (`%k used but not defined`).
+    incr_used = keep_iv
+    if !incr_used && carried_val isa SSAValue
         for (sidx, sentry) in after.body
             sidx == carried_val.id && continue
             if _refs_ssa_deep(sentry.stmt, carried_val); incr_used = true; break; end
@@ -733,11 +792,13 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
         push!(for_body.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
 
-    # ContinueOp with non-IV carried values
+    # ContinueOp carried values. At `iv_pos` (when kept) this is `carried_val`, the
+    # increment SSA = `iv + step`; its last value is `upper` (non-empty) so the kept
+    # carry's result matches `while`-counted post-increment semantics.
     cont_values = IRValue[]
     if after.terminator isa YieldOp
         for (i, v) in enumerate(after.terminator.values)
-            i == iv_pos && continue
+            (i == iv_pos && !keep_iv) && continue
             push!(cont_values, v)
         end
     end
@@ -747,7 +808,7 @@ function try_promote_for(op, idx::Int, parent_block::Block, new_body::SSAMap,
     remap_block_args!(for_body, arg_remap)
     step = remap_value(step, arg_remap)
 
-    return (ForOp(lower, upper, step, iv_arg, for_body, non_iv_inits), iv_pos)
+    return (ForOp(lower, upper, step, iv_arg, for_body, carry_inits), keep_iv ? Int[] : [iv_pos])
 end
 
 #=============================================================================

--- a/src/structurize/promote.jl
+++ b/src/structurize/promote.jl
@@ -93,6 +93,11 @@ function promote_loops!(block::Block, ctx::StructurizeCtx)
                     new_gf = Expr(:call, Core.getfield, SSAValue(loop_ssa), adjusted)
                     push!(new_body, (idx, new_gf, entry.type, entry.flag))
                 else
+                    # `upper` alias for a removed IV/shadow position. Since PLAN7
+                    # keeps every *escaping* removed position as a real carry, this
+                    # branch is reachable only for a provably-dead getfield (the
+                    # IV-escape gate returned false), so the alias is never observed.
+                    @assert !_ssa_used_in_block(SSAValue(idx), idx, block) "escaping removed position aliased to upper (PLAN7 invariant violated)"
                     push!(new_body, (idx, for_op.upper, entry.type, entry.flag))
                 end
             else
@@ -465,15 +470,19 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
         _ssa_used_in_block(SSAValue(gf_idx), gf_idx, parent_block) && return (loop, Int[], Dict{Int,Int}())
     end
 
-    # IV-escape gate (ISSUES.md #3): removed positions (the IV and its shadows) are
-    # aliased to `upper` post-loop — wrong for an empty loop, whose final IV is the
-    # init. If any such position (one that aliases to `upper`, i.e. not a duplicate
-    # carry redirected to a real carry) is read after the loop, keep the LoopOp.
-    # A genuine `for i in lo:hi` never reads its IV afterwards, so this stays inert.
+    # IV-escape gate (ISSUES.md #3 / PLAN7 Phase 2): removed positions (the IV and
+    # its value#1 shadows) would otherwise be aliased to `upper` post-loop — wrong
+    # for an empty loop, whose final IV is the init. Rather than decline the whole
+    # promotion, *partition* `removed`: any escaping position becomes a real kept
+    # carry (read back normally), while the rest stay removed (their `upper` alias
+    # is then provably dead). Duplicate-carry redirects stay removed (an Undef-init
+    # dup is not a meaningful escaping value; it is folded into its survivor).
+    kept = Int[]
     for r in removed
         haskey(carry_redirect, r) && continue
-        loop_result_pos_escapes(idx, r, parent_block) && return (loop, Int[], Dict{Int,Int}())
+        loop_result_pos_escapes(idx, r, parent_block) && push!(kept, r)
     end
+    removed = setdiff(removed, kept)   # run before any count(p<…, removed)/carry_types
 
     # --- Build ForOp ---
     lower = loop.init_values[iv_pos]
@@ -489,19 +498,24 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
     for_body = Block()
     arg_remap = Dict{Int, BlockArgument}()
 
-    # Map IV and shadow IVs to ForOp's iv_arg (skip duplicate carries)
+    # Map (still-)removed IV / shadow IVs to ForOp's iv_arg (skip duplicate carries)
     for r in removed
         haskey(carry_redirect, r) && continue
         arg_remap[body.args[r].id] = iv_arg
     end
 
-    # Non-IV, non-shadow, non-duplicate args get fresh BlockArguments
+    # Retained carries — genuine carries AND kept escaping IV/shadows (no longer in
+    # `removed`) — get fresh BlockArguments in original index order, each with its
+    # own init. A kept escaping IV/shadow is the current IV *in-body* (e.g. the same
+    # value an `acc += i` reads), so its in-body uses must resolve to `iv_arg`; its
+    # fresh for-arg is then a write-only carry slot that only exposes the post-loop
+    # result. A genuine carry maps its body uses to its own for-arg as usual.
     non_iv_inits = IRValue[]
     for (i, arg) in enumerate(body.args)
         i ∈ removed && continue
         for_arg = BlockArgument(alloc_arg!(ctx), arg.type)
         push!(for_body.args, for_arg)
-        arg_remap[arg.id] = for_arg
+        arg_remap[arg.id] = (i ∈ kept) ? iv_arg : for_arg
         push!(non_iv_inits, loop.init_values[i])
     end
 
@@ -510,23 +524,53 @@ function try_promote_for_from_loop(loop::LoopOp, idx::Int, parent_block::Block,
         arg_remap[body.args[dup_pos].id] = arg_remap[body.args[surv_pos].id]
     end
 
-    # Body: stmts before the exit IfOp + continue branch stmts (minus IV increment)
+    # ContinueOp values. A kept escaping position must carry `iv_arg` itself — NOT
+    # its lifted continue, which is the *advanced* value `iv+step` (the iterate
+    # protocol advances before re-checking, so that continue equals `upper`, the
+    # post-loop bound). Carrying `iv_arg` makes the kept carry's last value the last
+    # in-body IV (`upper − step`), matching the LoopOp's break (the pre-advance
+    # current value); the empty range is guarded by the outer `if`, so the init is
+    # only read when the loop ran (PLAN7 §3 — the research answer is wrong here).
+    cont_values = IRValue[]
+    for (i, v) in enumerate(continue_op.values)
+        i ∈ removed && continue
+        push!(cont_values, i ∈ kept ? iv_arg : v)
+    end
+
+    # The IV increment (`step_ssa = iv + step`) is implicit in the range. Kept
+    # carries reference `iv_arg`, not the increment, so the statement is needed only
+    # if some other retained body stmt or surviving carried value reads it. Keep it
+    # iff referenced — a dead increment is harmless, a missing one dangles.
     last_idx = body.body.ssa_idxes[end]
+    incr_used = false
+    if step_ssa !== nothing
+        for v in cont_values
+            v isa SSAValue && v.id == step_ssa && (incr_used = true; break)
+        end
+        if !incr_used
+            for (sidx, sentry) in body.body
+                sidx == last_idx && break
+                _refs_ssa_deep(sentry.stmt, SSAValue(step_ssa)) && (incr_used = true; break)
+            end
+        end
+        if !incr_used
+            for (sidx, sentry) in cont_region.body
+                sidx == step_ssa && continue
+                _refs_ssa_deep(sentry.stmt, SSAValue(step_ssa)) && (incr_used = true; break)
+            end
+        end
+    end
+
+    # Body: stmts before the exit IfOp + continue branch stmts (minus dead increment)
     for (sidx, sentry) in body.body
         sidx == last_idx && break
         push!(for_body.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
     for (sidx, sentry) in cont_region.body
-        step_ssa !== nothing && sidx == step_ssa && continue  # skip IV increment
+        step_ssa !== nothing && sidx == step_ssa && !incr_used && continue  # drop dead IV increment
         push!(for_body.body, (sidx, sentry.stmt, sentry.type, sentry.flag))
     end
 
-    # ContinueOp with non-IV, non-shadow values
-    cont_values = IRValue[]
-    for (i, v) in enumerate(continue_op.values)
-        i ∈ removed && continue
-        push!(cont_values, v)
-    end
     for_body.terminator = ContinueOp(cont_values)
 
     remap_block_args!(for_body, arg_remap)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -243,14 +243,13 @@ end
 end
 
 @testset "counting loop whose IV escapes promotes to a kept-carry ForOp" begin
-    # `i=0; while i<n; i+=1; return i` reads the induction variable AFTER the loop.
-    # A ForOp does not carry its IV as a result, so an earlier promotion aliased the
-    # post-loop read to the bound — correct only when the loop ran. For the empty
-    # case (init ≥ bound, e.g. n ≤ 0) the IV keeps its init, so the alias returned
-    # the bound: a silent miscompile (ISSUES.md #3). It now promotes to a ForOp that
-    # *keeps* the escaping IV as an ordinary carried value (PLAN7), so the post-loop
-    # read is a normal result, correct for both the empty (= init 0) and non-empty
-    # (= n) cases.
+    # `i=0; while i<n; i+=1; return i` reads the induction variable after the loop.
+    # A ForOp does not carry its IV as a result, so promotion keeps the escaping IV
+    # as an ordinary carried value rather than dropping it and aliasing the post-loop
+    # read to the bound. The alias would be right only when the loop ran; for the
+    # empty case (init >= bound, e.g. n <= 0) the IV keeps its init. The carried
+    # value reads back normally and is correct for both the empty (= init 0) and
+    # non-empty (= n) cases.
     sci, _ = code_structured(Tuple{Int}) do n::Int
         i = 0
         while i < n

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -242,8 +242,15 @@ end
     @test validate_ssa_defs(sci2)
 end
 
-@testset "ForOp detection during CFG analysis" begin
-    # Test that counting loops are detected as ForOp during CFG analysis
+@testset "counting loop whose IV escapes promotes to a kept-carry ForOp" begin
+    # `i=0; while i<n; i+=1; return i` reads the induction variable AFTER the loop.
+    # A ForOp does not carry its IV as a result, so an earlier promotion aliased the
+    # post-loop read to the bound — correct only when the loop ran. For the empty
+    # case (init ≥ bound, e.g. n ≤ 0) the IV keeps its init, so the alias returned
+    # the bound: a silent miscompile (ISSUES.md #3). It now promotes to a ForOp that
+    # *keeps* the escaping IV as an ordinary carried value (PLAN7), so the post-loop
+    # read is a normal result, correct for both the empty (= init 0) and non-empty
+    # (= n) cases.
     sci, _ = code_structured(Tuple{Int}) do n::Int
         i = 0
         while i < n
@@ -252,10 +259,16 @@ end
         return i
     end |> only
 
-    # Counting loop should produce ForOp
     loop_ops = filter(x -> x isa ControlFlowOp, collect(statements(sci.entry.body)))
     @test !isempty(loop_ops)
     @test loop_ops[1] isa ForOp
+    @test !any(x -> x isa WhileOp, statements(sci.entry.body))
+
+    # Empty by negative bound returns the init (0), not the bound; n>0 returns n.
+    counted(n) = (i = 0; while i < n; i += 1; end; i)
+    for n in (-3, 0, 1, 5)
+        @test execute(sci, n) == counted(n)
+    end
 end
 
 @testset "code_structured single-argument form" begin

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -299,6 +299,92 @@ end
     end
 end
 
+@testset "empty counted while-loop returns its init, not its bound (ISSUES #3)" begin
+    # A `while x < n` whose induction value starts at or above the bound runs zero
+    # times, so the loop result must be the *init* (the unchanged IV), not the
+    # bound. A ForOp does not carry its IV as a result, so an earlier promotion
+    # aliased a post-loop read of the IV to the loop's exclusive `upper` — correct
+    # only when the body ran; for the empty case (init ≥ bound) the final IV is the
+    # init, so the alias returned the bound: a silent miscompile (`fixed(5) → 5`,
+    # should be 100 — ISSUES.md #3). It now promotes to a ForOp that *keeps* the
+    # escaping IV as an ordinary carried value (PLAN7): the result is read normally
+    # and is correct for both the empty (= init) and non-empty (= last continue =
+    # upper) cases. The standing loop fuzzers all start the IV *below* the bound
+    # (`for k in 1:n`), so they miss this; the exec-over-empty checks below are what
+    # actually guard it — never remove them.
+    fixed(n::Int) = (x = 100; while x < n; x += 1; end; x)
+    ir, _ = only(code_ircode(fixed, Tuple{Int}))
+    # init=100 spans empty (n ≤ 100) and non-empty (n > 100); both promote modes.
+    for promote in (false, true)
+        sci = StructuredIRCode(ir; promote)
+        for n in (0, 5, 50, 100, 150, 200)
+            @test execute(sci, n) == fixed(n)
+        end
+    end
+    # The IV escapes (`return x`), but the kept-carry promotion makes it a correct
+    # ForOp (lower = init 100, step 1) rather than demoting it.
+    sci_p = StructuredIRCode(ir; promote=true)
+    @test count_stmts(sci_p.entry, s -> s isa WhileOp) == 0
+    @test count_stmts(sci_p.entry, s -> s isa ForOp) == 1
+    for_op = only(filter(x -> x isa ForOp, collect(statements(sci_p.entry.body))))
+    @test for_op.lower == 100
+    @test for_op.step == 1
+
+    # Inclusive bound (`while x <= n`): empty when init > n (so n < 100 is empty).
+    fixed_le(n::Int) = (x = 100; while x <= n; x += 1; end; x)
+    for n in (0, 50, 99, 100, 101, 200)
+        @test @roundtrip fixed_le(n)
+    end
+
+    # Step > 1 with a separate accumulator carried alongside the escaping IV — both
+    # the kept IV carry and the accumulator ride the ForOp correctly.
+    fixed_step(n::Int) = (x = 100; s = 0; while x < n; s += x; x += 2; end; x + s)
+    for n in (0, 50, 100, 150, 200)
+        @test @roundtrip fixed_step(n)
+    end
+
+    # A genuine counted `for i in 1:n` does NOT read `i` after the loop (Julia
+    # scopes it), so the gate must not fire — it still promotes to a ForOp. Empty
+    # range (n < 1) included to confirm the well-behaved counted case is untouched.
+    forsum(n::Int) = (acc = 0; for i in 1:n; acc += i; end; acc)
+    ir_for, _ = only(code_ircode(forsum, Tuple{Int}))
+    sci_for = StructuredIRCode(ir_for; promote=true)
+    @test count_stmts(sci_for.entry, s -> s isa ForOp) == 1   # still promotes
+    for n in (-1, 0, 1, 5)
+        @test execute(sci_for, n) == forsum(n)
+    end
+end
+
+@testset "escaping IV ForOp: step>1 and inclusive <= bound (PLAN7)" begin
+    # The kept-IV ForOp must be correct for a non-unit step and for an inclusive
+    # `<=` bound (which adjusts the *range* control by +1 but not the carried value).
+
+    # step 2: counted2(5) iterates i=0,2,4 then continues to 6 (the first value
+    # failing i<5), so the escaping IV result is 6; empty (n≤0) returns init 0.
+    counted2(n::Int) = (i = 0; while i < n; i += 2; end; i)
+    ir2, _ = only(code_ircode(counted2, Tuple{Int}))
+    sci2 = StructuredIRCode(ir2; promote=true)
+    @test count_stmts(sci2.entry, s -> s isa ForOp) == 1
+    let for_op = only(filter(x -> x isa ForOp, collect(statements(sci2.entry.body))))
+        @test for_op.lower == 0
+        @test for_op.step == 2
+    end
+    for n in (-3, 0, 1, 2, 5, 6, 50, 200)
+        @test execute(sci2, n) == counted2(n)
+    end
+    @test counted2(5) == 6 && execute(sci2, 5) == 6   # the step-2 exit value
+
+    # inclusive `<=` whose IV escapes: `while i<=n; i+=1; return i`. The exclusive
+    # range upper is n+1, but the carried IV value is unaffected by that adjustment.
+    counted_le(n::Int) = (i = 0; while i <= n; i += 1; end; i)
+    irle, _ = only(code_ircode(counted_le, Tuple{Int}))
+    scile = StructuredIRCode(irle; promote=true)
+    @test count_stmts(scile.entry, s -> s isa ForOp) == 1
+    for n in (-3, -1, 0, 1, 2, 5, 50, 200)
+        @test execute(scile, n) == counted_le(n)
+    end
+end
+
 @testset "the core walk emits only LoopOp (promotion is a post-pass)" begin
     # With `promote=false`, every loop must be a generic LoopOp — no ForOp/WhileOp
     # leaks from the core walk. (With promotion they become For/While; that path is
@@ -653,15 +739,18 @@ end
         while x < n; x += 1; end
         return x
     end
-    # The pre-header fix lives in the core lift, so assert it there across every n —
+    # The pre-header fix lives in the core lift, so assert it across every n —
     # including the empty-loop cases (init already ≥ bound) where the result is the
-    # branch selection (10/100) itself. (A separate, pre-existing *promotion* bug
-    # miscompiles an empty counted while-loop, returning the bound instead of the
-    # init — ISSUES.md #3 — so the empty case is asserted at promote=false here.)
+    # branch selection (10/100) itself. Both promote modes: the empty case once
+    # exposed a separate promotion bug (an empty counted while-loop returned its
+    # bound instead of its init — ISSUES.md #3), now closed by the IV-escape gate,
+    # so promote=true must agree across the full range too.
     ir_np, _ = only(code_ircode(meh1, Tuple{Bool, Int}))
-    sci_np = StructuredIRCode(ir_np; promote=false)
-    for c in (false, true), n in (0, 5, 50, 200)
-        @test execute(sci_np, c, n) == meh1(c, n)
+    for promote in (false, true)
+        sci_m = StructuredIRCode(ir_np; promote)
+        for c in (false, true), n in (0, 5, 50, 200)
+            @test execute(sci_m, c, n) == meh1(c, n)
+        end
     end
     # The literal ISSUES.md #2 repro through the full pipeline: at n=200 the loop
     # runs for both arms, so the result is the loop output (200), not the entry

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -299,19 +299,17 @@ end
     end
 end
 
-@testset "empty counted while-loop returns its init, not its bound (ISSUES #3)" begin
+@testset "empty counted while-loop returns its init, not its bound" begin
     # A `while x < n` whose induction value starts at or above the bound runs zero
-    # times, so the loop result must be the *init* (the unchanged IV), not the
-    # bound. A ForOp does not carry its IV as a result, so an earlier promotion
-    # aliased a post-loop read of the IV to the loop's exclusive `upper` — correct
-    # only when the body ran; for the empty case (init ≥ bound) the final IV is the
-    # init, so the alias returned the bound: a silent miscompile (`fixed(5) → 5`,
-    # should be 100 — ISSUES.md #3). It now promotes to a ForOp that *keeps* the
-    # escaping IV as an ordinary carried value (PLAN7): the result is read normally
-    # and is correct for both the empty (= init) and non-empty (= last continue =
-    # upper) cases. The standing loop fuzzers all start the IV *below* the bound
-    # (`for k in 1:n`), so they miss this; the exec-over-empty checks below are what
-    # actually guard it — never remove them.
+    # times, so the loop result must be the init (the unchanged IV), not the bound.
+    # A ForOp does not carry its IV as a result, so promotion keeps the escaping IV
+    # as an ordinary carried value rather than dropping it and aliasing the post-loop
+    # read to `upper`. That alias would equal the IV only when the body ran; for the
+    # empty case (init >= bound) the final IV is the init. The carried value reads
+    # back normally and is correct for both the empty (= init) and non-empty
+    # (= last continue = upper) cases. The standing loop fuzzers all start the IV
+    # below the bound (`for k in 1:n`), so they miss this; the exec-over-empty checks
+    # below are what guard it, so never remove them.
     fixed(n::Int) = (x = 100; while x < n; x += 1; end; x)
     ir, _ = only(code_ircode(fixed, Tuple{Int}))
     # init=100 spans empty (n ≤ 100) and non-empty (n > 100); both promote modes.
@@ -321,8 +319,8 @@ end
             @test execute(sci, n) == fixed(n)
         end
     end
-    # The IV escapes (`return x`), but the kept-carry promotion makes it a correct
-    # ForOp (lower = init 100, step 1) rather than demoting it.
+    # The IV escapes (`return x`) and is kept as a carry, so this is a correct ForOp
+    # (lower = init 100, step 1).
     sci_p = StructuredIRCode(ir; promote=true)
     @test count_stmts(sci_p.entry, s -> s isa WhileOp) == 0
     @test count_stmts(sci_p.entry, s -> s isa ForOp) == 1
@@ -336,16 +334,16 @@ end
         @test @roundtrip fixed_le(n)
     end
 
-    # Step > 1 with a separate accumulator carried alongside the escaping IV — both
+    # Step > 1 with a separate accumulator carried alongside the escaping IV. Both
     # the kept IV carry and the accumulator ride the ForOp correctly.
     fixed_step(n::Int) = (x = 100; s = 0; while x < n; s += x; x += 2; end; x + s)
     for n in (0, 50, 100, 150, 200)
         @test @roundtrip fixed_step(n)
     end
 
-    # A genuine counted `for i in 1:n` does NOT read `i` after the loop (Julia
-    # scopes it), so the gate must not fire — it still promotes to a ForOp. Empty
-    # range (n < 1) included to confirm the well-behaved counted case is untouched.
+    # A genuine counted `for i in 1:n` does not read `i` after the loop (Julia
+    # scopes it out), so the IV is dropped and it still promotes to a ForOp. The
+    # empty range (n < 1) confirms the well-behaved counted case is untouched.
     forsum(n::Int) = (acc = 0; for i in 1:n; acc += i; end; acc)
     ir_for, _ = only(code_ircode(forsum, Tuple{Int}))
     sci_for = StructuredIRCode(ir_for; promote=true)
@@ -355,9 +353,9 @@ end
     end
 end
 
-@testset "escaping IV ForOp: step>1 and inclusive <= bound (PLAN7)" begin
+@testset "escaping IV ForOp: step>1 and inclusive <= bound" begin
     # The kept-IV ForOp must be correct for a non-unit step and for an inclusive
-    # `<=` bound (which adjusts the *range* control by +1 but not the carried value).
+    # `<=` bound (which adjusts the range control by +1 but not the carried value).
 
     # step 2: counted2(5) iterates i=0,2,4 then continues to 6 (the first value
     # failing i<5), so the escaping IV result is 6; empty (n≤0) returns init 0.
@@ -739,12 +737,12 @@ end
         while x < n; x += 1; end
         return x
     end
-    # The pre-header fix lives in the core lift, so assert it across every n —
-    # including the empty-loop cases (init already ≥ bound) where the result is the
-    # branch selection (10/100) itself. Both promote modes: the empty case once
-    # exposed a separate promotion bug (an empty counted while-loop returned its
-    # bound instead of its init — ISSUES.md #3), now closed by the IV-escape gate,
-    # so promote=true must agree across the full range too.
+    # The pre-header fix lives in the core lift, so assert it across every n,
+    # including the empty-loop cases (init already >= bound) where the result is the
+    # branch selection (10/100) itself. Both promote modes are checked: the empty
+    # case once exposed a separate promotion bug where an empty counted while-loop
+    # returned its bound instead of its init, now closed by keeping the escaping IV
+    # as a carry, so promote=true must agree across the full range too.
     ir_np, _ = only(code_ircode(meh1, Tuple{Bool, Int}))
     for promote in (false, true)
         sci_m = StructuredIRCode(ir_np; promote)

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -106,10 +106,10 @@ end  # acyclic regions
 
 @testset "simple loop structure - escaping IV is a kept-carry ForOp" begin
     # `i=0; while i<n; i+=1; return i` reads the IV after the loop. A ForOp can't
-    # carry the IV as a range result, but it *can* keep it as an ordinary carried
-    # value (PLAN7): the post-loop read is then a normal result, correct for both
-    # the empty case (= init 0) and non-empty (= n) — earlier this aliased the read
-    # to the bound and miscompiled the empty case (ISSUES.md #3).
+    # carry the IV as a range result, but it can keep it as an ordinary carried
+    # value, so the post-loop read is a normal result, correct for both the empty
+    # case (= init 0) and non-empty (= n). Dropping it and aliasing the read to the
+    # bound would miscompile the empty case.
     @test @filecheck begin
         code_structured(Tuple{Int}) do n::Int
             @check "for"
@@ -196,10 +196,10 @@ end  # CFG analysis
 
 @testset "bounded counter with escaping IV is a kept-carry ForOp" begin
     # The induction variable `i` is returned, so the ForOp keeps it as an ordinary
-    # carried value (PLAN7) instead of dropping it: the range still drives iteration
-    # (lower 0, upper n, step 1) while the kept carry exposes the post-loop value,
-    # correct for the empty case (= init 0) too. Earlier this aliased the read to
-    # the bound and miscompiled the empty case (ISSUES.md #3).
+    # carried value instead of dropping it. The range still drives iteration (lower
+    # 0, upper n, step 1) while the kept carry exposes the post-loop value, correct
+    # for the empty case (= init 0) too. Dropping it and aliasing the read to the
+    # bound would miscompile the empty case.
     @test @filecheck begin
         code_structured(Tuple{Int}) do n::Int
             @check "for"
@@ -1602,16 +1602,15 @@ end
 
 @testset "for-in-range whose loop var escapes is a kept-carry ForOp" begin
     # `for i in 1:n; last = i; end; return last` copies the loop variable into
-    # `last`. For a `1:n` range the iterate protocol makes `last` a value#1 *shadow*
-    # of the loop state, and `last` is read after the loop. An earlier promotion
-    # aliased that shadow to the range's upper bound, returning `n+1` instead of `n`
-    # — a silent miscompile (`forlast(1) → 2`) that had NO execution check, so it
-    # went unnoticed (the ISSUES.md #3 root cause via the direct iterate-protocol
-    # path). It now promotes to a ForOp that *keeps* `last` as an ordinary carried
-    # value whose continue is the induction variable (PLAN7 Phase 2 §3 — NOT the
-    # lifted continue, which is the advanced `iv+step` = the bound): the last value
-    # is the last in-body IV (= n), and the empty range is guarded by the outer
-    # `if` so the init (0) is returned for n < 1.
+    # `last`. For a `1:n` range the iterate protocol makes `last` a value#1 shadow of
+    # the loop state, and `last` is read after the loop. Promotion keeps `last` as an
+    # ordinary carried value whose continue is the induction variable, not the lifted
+    # continue (which is the advanced `iv+step`, equal to the bound). The last value
+    # is then the last in-body IV (= n), and the empty range is guarded by the outer
+    # `if`, so the init (0) is returned for n < 1. Aliasing the shadow to the range's
+    # upper bound instead would return `n+1`, a miscompile that earlier had no
+    # execution check to catch it (`forlast(1)` gave 2). The exec checks below cover
+    # the empty case, so keep them.
     @test @filecheck begin
         code_structured(Tuple{Int}) do n
             last = 0

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -1600,20 +1600,22 @@ end
 
 end
 
-@testset "for-in-range whose loop var escapes is not a buggy ForOp" begin
+@testset "for-in-range whose loop var escapes is a kept-carry ForOp" begin
     # `for i in 1:n; last = i; end; return last` copies the loop variable into
-    # `last`. For a `1:n` range the iterate protocol makes `last` a *shadow* of the
-    # loop state (value == state), and `last` is read after the loop. Promoting to
-    # a ForOp aliased that shadow to the range's upper bound, returning `n+1`
-    # instead of `n` — a silent miscompile (`forlast(1) → 2`) that had NO execution
-    # check, so it went unnoticed (the ISSUES.md #3 root cause via the direct
-    # iterate-protocol path). The IV-escape gate keeps it a LoopOp, carrying `last`
-    # correctly. A for-in-range with a true accumulator still promotes (see the
-    # "Julia for-in-range (1:n) produces ForOp" testset above).
+    # `last`. For a `1:n` range the iterate protocol makes `last` a value#1 *shadow*
+    # of the loop state, and `last` is read after the loop. An earlier promotion
+    # aliased that shadow to the range's upper bound, returning `n+1` instead of `n`
+    # — a silent miscompile (`forlast(1) → 2`) that had NO execution check, so it
+    # went unnoticed (the ISSUES.md #3 root cause via the direct iterate-protocol
+    # path). It now promotes to a ForOp that *keeps* `last` as an ordinary carried
+    # value whose continue is the induction variable (PLAN7 Phase 2 §3 — NOT the
+    # lifted continue, which is the advanced `iv+step` = the bound): the last value
+    # is the last in-body IV (= n), and the empty range is guarded by the outer
+    # `if` so the init (0) is returned for n < 1.
     @test @filecheck begin
         code_structured(Tuple{Int}) do n
             last = 0
-            @check "loop"
+            @check "for"
             for i in 1:n
                 last = i
             end
@@ -1628,11 +1630,41 @@ end
         end
         return last
     end |> only
-    @test count_stmts(sci.entry, x -> x isa ForOp) == 0
+    @test count_stmts(sci.entry, x -> x isa ForOp) == 1
 
     forlast(n) = (last = 0; for i in 1:n; last = i; end; last)
-    for n in (-3, 0, 1, 3, 5)
+    for n in (-3, 0, 1, 2, 3, 5, 50, 200)
         @test execute(sci, n) == forlast(n)   # empty → 0; else → n (was n+1 when buggy)
+    end
+
+    # Step ≠ 1 (`1:2:n`): the last in-body odd ≤ n. Empty → init 0.
+    forlast2(n) = (last = 0; for i in 1:2:n; last = i; end; last)
+    sci2, _ = code_structured(Tuple{Int}) do n
+        last = 0
+        for i in 1:2:n
+            last = i
+        end
+        return last
+    end |> only
+    @test count_stmts(sci2.entry, x -> x isa ForOp) == 1
+    for n in (-3, 0, 1, 2, 4, 5, 6, 50, 200)
+        @test execute(sci2, n) == forlast2(n)
+    end
+
+    # Escaping index-capture shadow read *in-body* alongside a real accumulator
+    # (the shadow's in-body uses must resolve to the IV, not the write-only carry).
+    forboth(n) = (last = 0; acc = 0; for i in 1:n; acc += i; last = i; end; last + acc)
+    sci3, _ = code_structured(Tuple{Int}) do n
+        last = 0; acc = 0
+        for i in 1:n
+            acc += i
+            last = i
+        end
+        return last + acc
+    end |> only
+    @test count_stmts(sci3.entry, x -> x isa ForOp) == 1
+    for n in (-3, 0, 1, 2, 5, 50, 200)
+        @test execute(sci3, n) == forboth(n)
     end
 end
 

--- a/test/structurize.jl
+++ b/test/structurize.jl
@@ -104,21 +104,26 @@ end  # acyclic regions
 
 @testset "cyclic regions" begin
 
-@testset "simple loop structure - ForOp" begin
+@testset "simple loop structure - escaping IV is a kept-carry ForOp" begin
+    # `i=0; while i<n; i+=1; return i` reads the IV after the loop. A ForOp can't
+    # carry the IV as a range result, but it *can* keep it as an ordinary carried
+    # value (PLAN7): the post-loop read is then a normal result, correct for both
+    # the empty case (= init 0) and non-empty (= n) — earlier this aliased the read
+    # to the bound and miscompiled the empty case (ISSUES.md #3).
     @test @filecheck begin
         code_structured(Tuple{Int}) do n::Int
+            @check "for"
             i = 0
-            @check "for %{{.*}} ="
             while i < n
                 i += 1
             end
-            @check "continue"
             return i
         end
     end
     f_count = (n::Int) -> (i = 0; while i < n; i += 1; end; i)
     @test @roundtrip f_count(5)
     @test @roundtrip f_count(0)
+    @test @roundtrip f_count(-3)   # empty by negative bound → init (0), not the bound
 end
 
 @testset "loop with condition" begin
@@ -189,20 +194,23 @@ end  # CFG analysis
 
 @testset "ForOp detection" begin
 
-@testset "bounded counter" begin
+@testset "bounded counter with escaping IV is a kept-carry ForOp" begin
+    # The induction variable `i` is returned, so the ForOp keeps it as an ordinary
+    # carried value (PLAN7) instead of dropping it: the range still drives iteration
+    # (lower 0, upper n, step 1) while the kept carry exposes the post-loop value,
+    # correct for the empty case (= init 0) too. Earlier this aliased the read to
+    # the bound and miscompiled the empty case (ISSUES.md #3).
     @test @filecheck begin
         code_structured(Tuple{Int}) do n::Int
+            @check "for"
             i = 0
-            @check "for %{{.*}} ="
             while i < n
                 i += 1
             end
-            @check "continue"
             return i
         end
     end
 
-    # Also verify ForOp bounds programmatically (FileCheck can't check these)
     sci, _ = code_structured(Tuple{Int}) do n::Int
         i = 0
         while i < n
@@ -210,13 +218,20 @@ end  # CFG analysis
         end
         return i
     end |> only
-    for_ops = filter(x -> x isa ForOp, collect(statements(sci.entry.body)))
-    @test length(for_ops) == 1
+    @test count_stmts(sci.entry, x -> x isa ForOp) == 1
+    @test count_stmts(sci.entry, x -> x isa WhileOp) == 0
 
-    for_op = for_ops[1]
+    for_op = only(filter(x -> x isa ForOp, collect(statements(sci.entry.body))))
     @test for_op.lower == 0
-    @test for_op.upper isa Core.Argument
+    @test for_op.upper isa Core.Argument   # the bound `n`
     @test for_op.step == 1
+
+    # Execution across empty (n ≤ 0 → init 0) and non-empty (→ n); the empty case
+    # is what the buggy ForOp promotion got wrong (it returned the bound).
+    counted(n) = (i = 0; while i < n; i += 1; end; i)
+    for n in (-3, 0, 1, 5, 10)
+        @test execute(sci, n) == counted(n)
+    end
 end
 
 @testset "inclusive bound (<=) gets exclusive adjustment" begin
@@ -1585,12 +1600,20 @@ end
 
 end
 
-@testset "for-in-range produces valid ForOp" begin
-    # Native for-in-range is promoted to ForOp
+@testset "for-in-range whose loop var escapes is not a buggy ForOp" begin
+    # `for i in 1:n; last = i; end; return last` copies the loop variable into
+    # `last`. For a `1:n` range the iterate protocol makes `last` a *shadow* of the
+    # loop state (value == state), and `last` is read after the loop. Promoting to
+    # a ForOp aliased that shadow to the range's upper bound, returning `n+1`
+    # instead of `n` — a silent miscompile (`forlast(1) → 2`) that had NO execution
+    # check, so it went unnoticed (the ISSUES.md #3 root cause via the direct
+    # iterate-protocol path). The IV-escape gate keeps it a LoopOp, carrying `last`
+    # correctly. A for-in-range with a true accumulator still promotes (see the
+    # "Julia for-in-range (1:n) produces ForOp" testset above).
     @test @filecheck begin
         code_structured(Tuple{Int}) do n
             last = 0
-            @check "for"
+            @check "loop"
             for i in 1:n
                 last = i
             end
@@ -1605,7 +1628,12 @@ end
         end
         return last
     end |> only
+    @test count_stmts(sci.entry, x -> x isa ForOp) == 0
 
+    forlast(n) = (last = 0; for i in 1:n; last = i; end; last)
+    for n in (-3, 0, 1, 3, 5)
+        @test execute(sci, n) == forlast(n)   # empty → 0; else → n (was n+1 when buggy)
+    end
 end
 
 @testset "for-in-range with Int32 bounds" begin


### PR DESCRIPTION
## Problem

A `ForOp` does not carry its induction variable (IV) as a result. The IV is
implicit in the half-open `lower:step:upper` range. When the loop-promotion
post-pass turned a counted loop into a `ForOp`, it dropped the IV carry and
aliased any post-loop read of it to the loop's exclusive `upper` bound.

That alias equals the final IV only when the loop body ran at least once. For an
empty (zero-trip) loop the final IV is the init, so the alias silently returned
the bound:

```julia
fixed(n)   = (x = 100; while x < n; x += 1; end; x)         # n ≤ 100 returned n, should be 100
forlast(n) = (last = 0; for i in 1:n; last = i; end; last)  # forlast(1) returned 2, should be 1
```

`forlast` is the `for`-in-range case: the iterate protocol makes `last` a shadow
of the loop state, aliased to the range's upper bound (`n + 1`). Both bugs were
silent: the loop corpora start the IV below the bound, and the structural tests
asserted `isa ForOp` with no execution check.

## Fix

Keep the escaping IV (or IV-derived shadow) as an ordinary `ForOp` loop-carried
value instead of dropping it and aliasing the read. The range still drives
iteration; the kept carry rides alongside and is read back as a normal result,
correct for both the empty case (= init) and the non-empty case (= last in-body
value). No change to the IR data model or the unstructurize lowering: a write-only
carry threads init to continue to result generically.

A new helper decides keep-vs-drop per result position, so a non-escaping IV (a
genuine `for i in 1:n; acc += i` where `i` is scoped out of the loop) is still
dropped and the common case is unchanged.

The two promotion routes are handled separately because they are not symmetric:

- The `while`-counted route (`slt`/`sle`/`ult`): the IV's break value equals its
  last continue (`upper`), so the kept carry's continue is the increment. Recovers
  `fixed`, step ≠ 1, inclusive `<=`, and IV-plus-accumulator loops.
- The `for`-in-range / iterate-protocol route (`===`): the protocol advances the
  state before re-checking the exit, so the lifted continue is the advanced value
  (`= upper`) while the correct post-loop value is the pre-advance current value.
  The kept carry therefore carries the induction variable itself (its last in-body
  value), not the lifted continue. A shadow that is also read in-body (e.g.
  `acc += i; last = i`) resolves its in-body uses to the IV, while its carry slot
  only exposes the post-loop result. Recovers `forlast`, step-range variants, and
  mixed shadow-plus-accumulator loops.