### PR TITLE
Report the returned value as a ReturnNode's operand

### DIFF
--- a/src/ir/inspect.jl
+++ b/src/ir/inspect.jl
@@ -139,6 +139,10 @@ operands(block::Block, inst::Instruction) = operands(block, inst[:stmt])
 
 operands(::Block, s::PiNode) = Any[s.val]
 operands(::Block, s::ControlFlowOp) = operands(s)
+# A `ReturnNode` reads the value it returns, except in its unreachable form, which
+# has no `val` at all. This mirrors how `walk_uses!` treats it, so that `operands`
+# and the use index agree on what a return reads.
+operands(::Block, s::ReturnNode) = isdefined(s, :val) ? Any[s.val] : Any[]
 # Alias statements (stmt IS a value) forward the value itself as their sole operand.
 operands(::Block, s::SSAValue) = Any[s]
 operands(::Block, s::BlockArgument) = Any[s]


### PR DESCRIPTION
operands(::Block, ::ReturnNode) fell through to the catch-all and reported no
operands, so a return appeared to read nothing, while walk_uses! -- and so the
use index -- correctly saw the value. Guard on isdefined(:val) for the
unreachable form, matching how walk_uses! already treats it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
